### PR TITLE
Added -trim option to installv3.sh for Snapdragon container

### DIFF
--- a/docker/px4-dev/DockerfileSnapdragon
+++ b/docker/px4-dev/DockerfileSnapdragon
@@ -12,7 +12,7 @@ RUN apt-get update \
     && apt-get -y --quiet --no-install-recommends install \
     git \
     make \
-	cmake \
+    cmake \
     unzip \
     xz-utils \
     wget \
@@ -40,7 +40,7 @@ ADD qualcomm_hexagon_sdk_lnx_3_0_eval.bin \
     /home/docker1000/cross_toolchain/downloads/qualcomm_hexagon_sdk_lnx_3_0_eval.bin
 
 RUN cd /home/docker1000/cross_toolchain \
-    && ./installv3.sh
+    && ./installv3.sh -trim
 ENV HEXAGON_SDK_ROOT="/home/docker1000/Qualcomm/Hexagon_SDK/3.0"
 ENV HEXAGON_TOOLS_ROOT="/home/docker1000/Qualcomm/HEXAGON_Tools/7.2.12/Tools"
 


### PR DESCRIPTION
Using -trim will substantially reduce the size of the SDK and Hexagon Tools install.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>