### PR TITLE
Snapdragon: reduce image size

### DIFF
--- a/docker/px4-dev/DockerfileSnapdragon
+++ b/docker/px4-dev/DockerfileSnapdragon
@@ -38,19 +38,19 @@ RUN cd /home/docker1000 \
 
 ADD qualcomm_hexagon_sdk_lnx_3_0_eval.bin \
     /home/docker1000/cross_toolchain/downloads/qualcomm_hexagon_sdk_lnx_3_0_eval.bin
+
 RUN cd /home/docker1000/cross_toolchain \
     && ./installv3.sh
-RUN rm /home/docker1000/cross_toolchain/downloads/qualcomm_hexagon_sdk_lnx_3_0_eval.bin \
-    && rm /home/docker1000/cross_toolchain/downloads/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf.tar.xz
 ENV HEXAGON_SDK_ROOT="/home/docker1000/Qualcomm/Hexagon_SDK/3.0"
 ENV HEXAGON_TOOLS_ROOT="/home/docker1000/Qualcomm/HEXAGON_Tools/7.2.12/Tools"
-ENV PATH="${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux/bin":$PATH
 
-ADD Flight_qrlSDK.zip \
-    /home/docker1000/cross_toolchain/downloads/Flight_qrlSDK.zip
 RUN cd /home/docker1000/cross_toolchain \
-    && ./qrlinux_sysroot.sh --clean
-RUN rm /home/docker1000/cross_toolchain/downloads/Flight_qrlSDK.zip
-ENV HEXAGON_ARM_SYSROOT="/home/docker1000/Qualcomm/qrlinux_v1.0_sysroot"
+    && ./trusty_sysroot.sh
+ENV HEXAGON_ARM_SYSROOT="/home/docker1000/Qualcomm/ubuntu_14.04_armv7_sysroot"
+
+RUN rm /home/docker1000/cross_toolchain/downloads/qualcomm_hexagon_sdk_lnx_3_0_eval.bin \
+    && rm /home/docker1000/cross_toolchain/downloads/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf.tar.xz
+
+ENV PATH="${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux/bin":$PATH
 
 CMD ["/bin/bash"]

--- a/docker/px4-dev/DockerfileSnapdragon
+++ b/docker/px4-dev/DockerfileSnapdragon
@@ -48,8 +48,7 @@ RUN cd /home/docker1000/cross_toolchain \
     && ./trusty_sysroot.sh
 ENV HEXAGON_ARM_SYSROOT="/home/docker1000/Qualcomm/ubuntu_14.04_armv7_sysroot"
 
-RUN rm /home/docker1000/cross_toolchain/downloads/qualcomm_hexagon_sdk_lnx_3_0_eval.bin \
-    && rm /home/docker1000/cross_toolchain/downloads/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf.tar.xz
+RUN rm /home/docker1000/cross_toolchain/downloads/*
 
 ENV PATH="${HEXAGON_SDK_ROOT}/gcc-linaro-4.9-2014.11-x86_64_arm-linux-gnueabihf_linux/bin":$PATH
 


### PR DESCRIPTION
This features two changes that should reduce the image size.

The current docker image is built with https://github.com/ATLFlight/cross_toolchain/pull/8.