### PR TITLE
Add docker file for RPi and Parrot Bebop toolchains

### DIFF
--- a/docker/px4-dev/DockerfileRPi
+++ b/docker/px4-dev/DockerfileRPi
@@ -1,0 +1,52 @@
+#
+# PX4 build for RPi and Parrot Bebop
+#
+# This contains the steps to build for the POSIX Linux running on
+# Raspberry Pi or Parrot Bebop
+#
+
+FROM ubuntu:xenial
+MAINTAINER Michael Schaeuble
+
+RUN apt-get update \
+    && apt-get -y --quiet --no-install-recommends install \
+    binutils \
+    file \
+    git \
+    make \
+    cmake \
+    unzip \
+    xz-utils \
+    ca-certificates \
+    ssh \
+    python \
+    python-empy \
+    ninja-build \
+    ccache \
+    sudo \
+    && apt-get -y autoremove \
+    && apt-get clean autoclean \
+    && rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log}
+
+RUN adduser --disabled-password --gecos '' --uid 1000 docker1000
+RUN adduser docker1000 sudo 
+
+USER docker1000
+
+ENV TERM=xterm
+ENV GIT_SSL_NO_VERIFY=true
+
+RUN cd /home/docker1000 \
+    && git clone https://github.com/pixhawk/rpi_toolchain.git
+
+USER root
+
+RUN cd /home/docker1000/rpi_toolchain \
+    && ./install_cross.sh /home/docker1000/rpi_toolchain_install \
+    && rm -rf /home/docker1000/rpi_toolchain
+
+USER docker1000
+
+ENV RPI_TOOLCHAIN_DIR=/home/docker1000/rpi_toolchain_install
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
This PR adds a docker file for the RPi and Parrot Bebop toolchains for Circle CI. Originally, this came up in PX4/Firmware#5504.

I tested it locally and the posix_rpi_cross and posix_bebop_default targets compiled without errors. However, I have one question: the script `./install_cross.sh` in line 45 has a few commands with sudo. When building the docker image, this didn't work, which is why I switch to the root user before that call. I am not sure about the solution and want to ask if there is a better way to do this?