### PR TITLE
move jinja to px4-dev-base for param generation

### DIFF
--- a/docker/px4-dev/Dockerfile_base
+++ b/docker/px4-dev/Dockerfile_base
@@ -36,12 +36,17 @@ RUN apt-get update \
 		zip \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
-	# coveralls
+	# pip
 	&& pip install --upgrade pip \
 	&& pip install setuptools \
+	# coveralls code coverage reporting
 	&& pip install cpp-coveralls \
+	# jinja template generation
+	&& pip install jinja2 \
+	# manual ccache setup
 	&& ln -s /usr/bin/ccache /usr/lib/ccache/cc \
 	&& ln -s /usr/bin/ccache /usr/lib/ccache/c++ \
+	# cleanup
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 ENV CCACHE_CPP2=1

--- a/docker/px4-dev/Dockerfile_simulation
+++ b/docker/px4-dev/Dockerfile_simulation
@@ -31,8 +31,6 @@ RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add
 	&& cd pymavlink \
 	&& git clone git://github.com/mavlink/mavlink.git && ln -s $PWD/mavlink/message_definitions ../ \
 	&& pip install . && cd .. && rm -rf pymavlink && rm -rf message_definitions \
-	# jinja
-	pip install jinja2 \
 	# cleanup
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 


### PR DESCRIPTION
@jgoppert I think this is what you actually need?

The images are a hierarchy with px4-dev-base containing all the core PX4 dependencies, but only able to build posix_sitl_default. We try to keep base and nuttx as small as possible because the CI systems pull them every single build.

base
--nuttx
----simulation
------ROS

Once this makes it to docker hub (~20 minutes after merging) you'll need to update the image the build system uses here - https://github.com/PX4/Firmware/blob/master/Tools/docker_run.sh#L15
If you just drop the date (the tag) it'll default to the latest. https://hub.docker.com/r/px4io/px4-dev-nuttx/builds/