### PR TITLE
Fix Gazebo crash in VMWare Fusion with OpenGL 3.3 support

### DIFF
--- a/docker/px4-dev/Dockerfile_simulation
+++ b/docker/px4-dev/Dockerfile_simulation
@@ -36,3 +36,8 @@ RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add
 
 # Some QT-Apps/Gazebo don't not show controls without this
 ENV QT_X11_NO_MITSHM 1
+
+# Gazebo 7 crashes on VM with OpenGL 3.3 support, so downgrade to OpenGL 2.1
+# http://answers.gazebosim.org/question/13214/virtual-machine-not-launching-gazebo/
+# https://www.mesa3d.org/vmware-guest.html
+ENV SVGA_VGPU10 0


### PR DESCRIPTION
So I have added env var SVGA_VGPU10=0 in order to disable OpenGL 3.3 for the container 
Source of the fix http://answers.gazebosim.org/question/13214/virtual-machine-not-launching-gazebo/