### PR TITLE
px4-dev-nuttx build nuttx tools

### DIFF
--- a/docker/px4-dev/Dockerfile_nuttx
+++ b/docker/px4-dev/Dockerfile_nuttx
@@ -8,19 +8,29 @@ MAINTAINER Daniel Agar <daniel@agar.ca>
 RUN dpkg --add-architecture i386 \
 	&& apt-get update \
 	&& apt-get -y --quiet --no-install-recommends install \
+		bison \
+		flex \
+		genromfs \
+		gperf \
 		libc6:i386 \
 		libgcc1:i386 \
+		libncurses-dev \
 		libstdc++5:i386 \
 		libstdc++6:i386 \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
+	# gcc-arm-embedded 5-2016-q3-update (https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads)
+	&& mkdir -p /opt/gcc && cd /opt/gcc \
+	&& wget -qO- "https://developer.arm.com/-/media/Files/downloads/gnu-rm/5_4-2016q3/gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2?product=GNU%20ARM%20Embedded%20Toolchain,32-bit,,Linux,5-2016-q3-update" | tar jx --strip 1 \
+	&& rm -rf /opt/gcc/share/doc \
+	# manual ccache setup for arm-none-eabi-g++/arm-none-eabi-gcc
+	&& ln -s /usr/bin/ccache /usr/lib/ccache/arm-none-eabi-g++ \
+	&& ln -s /usr/bin/ccache /usr/lib/ccache/arm-none-eabi-gcc \
+	# nuttx tools
+	&& git clone --depth 1 https://bitbucket.org/nuttx/tools.git /tmp/tools \
+	&& cd /tmp/tools/kconfig-frontends \
+	&& ./configure --enable-mconf -prefix=/usr && make && make install \
+	# cleanup
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
-RUN mkdir -p /opt/gcc && cd /opt/gcc && \
-	wget -qO- https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/+download/gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2 | tar jx --strip 1 && \
-	rm -rf /opt/gcc/share/doc
-
-RUN ln -s /usr/bin/ccache /usr/lib/ccache/arm-none-eabi-g++ \
-	&& ln -s /usr/bin/ccache /usr/lib/ccache/arm-none-eabi-gcc
 
 ENV PATH "$PATH:/opt/gcc/bin"


### PR DESCRIPTION
@davids5 FYI adding nuttx tools to px4-dev-nuttx. Primarily used in the builds, but can also be used locally quite easily.

Newer NuttX is running `make olddefconfig` at the end of configure.sh. https://bitbucket.org/nuttx/nuttx/src/cc1f7a63fa4180c3effb951f0b2f7d8df89e1fd3/tools/configure.sh?at=master&fileviewer=file-view-default#configure.sh-302

This should also make it slightly easier for people wanting to work on nuttx itself.