### PR TITLE
mavros add dockerfile, entrypoint and readme

### DIFF
--- a/docker/px4-dev/mavros/Dockerfile
+++ b/docker/px4-dev/mavros/Dockerfile
@@ -1,0 +1,26 @@
+FROM ros:kinetic-ros-base
+
+# Installation instructions: https://dev.px4.io/en/ros/mavros_installation.html
+
+RUN apt-get update && \
+    apt-get install -y python-wstool \
+                       python-rosinstall-generator \
+                       python-catkin-tools && \
+    mkdir -p ~/catkin_ws/src && \
+    catkin init --workspace ~/catkin_ws && \
+    wstool init ~/catkin_ws/src && \
+    rosinstall_generator --upstream mavros | tee /tmp/mavros.rosinstall && \
+    rosinstall_generator mavlink | tee -a /tmp/mavros.rosinstall && \
+    wstool merge -t ~/catkin_ws/src /tmp/mavros.rosinstall && \
+    wstool update -t ~/catkin_ws/src && \
+    rosdep install --from-paths ~/catkin_ws/src --ignore-src --rosdistro kinetic -y
+
+RUN ["/bin/bash", "-c", "source /opt/ros/kinetic/setup.bash && catkin build --workspace ~/catkin_ws"]
+
+RUN ~/catkin_ws/src/mavros/mavros/scripts/install_geographiclib_datasets.sh
+
+COPY entrypoint.sh /root/entrypoint.sh
+RUN chmod +x /root/entrypoint.sh
+
+ENTRYPOINT ["/root/entrypoint.sh"]
+CMD ["fcu_url:=udp://:14540@127.0.0.1:14557"]

--- a/docker/px4-dev/mavros/README.md
+++ b/docker/px4-dev/mavros/README.md
@@ -1,0 +1,28 @@
+# Mavros container
+## Quick start
+
+Run mavros on the default `fcu_url` (`udp://:14540@127.0.0.1:14557`) with the following command:
+
+    $ docker run --rm -it px4io/mavros
+
+## Custom Mavros arguments
+
+The entrypoint of the container makes it run mavros directly with the parameters you give (default is `fcu_url:="udp://:14540@127.0.0.1:14557"`):
+
+    $ docker run --rm -it -p 11311:11311 px4io/mavros fcu_url:="udp://:14540@127.0.0.1:14557"
+
+## Build mavros image
+
+You can build the image yourself by cloning this repository, navigating to this folder and running:
+
+    $ docker build -t <image_name_you_want> .
+
+## More details
+
+Note that mavros starts a ROS master if it doesn't find any, which is set to run on port "11311" in the Dockerfile.
+
+Thanks to the `-p 11311:11311` part of the command above, the container binds its `11311` port to `localhost:11311` on the host. Since ROS is looking for the master locally on this port by default, it means that the host now has a ROS master running on `http://localhost:11311`. Try, for instance:
+
+    $ rostopic list
+
+This setup can be quite useful; one can for instance run ROS nodes on different containers, all set to use the mavros container as their ROS master (check the `ROS_MASTER_URI` environment variable) while at the same time running ROS nodes transparently on the host.

--- a/docker/px4-dev/mavros/entrypoint.sh
+++ b/docker/px4-dev/mavros/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source ~/catkin_ws/devel/setup.bash
+export ROS_IP=`hostname -I`
+export ROS_MASTER_URI=http://`hostname -I`:11311
+
+echo "Running \"roslaunch mavros -p 11311 px4.launch $1\""
+roslaunch mavros -p 11311 px4.launch $1


### PR DESCRIPTION
The goal is for this image to replace `px4io/mavros` on the Docker Hub, because it is currently not maintained.