### PR TITLE
75 containers organization

### DIFF
--- a/docker/px4/README.md
+++ b/docker/px4/README.md
@@ -1,0 +1,39 @@
+# Purpose
+
+The containers in this directory are meant to be used in a "microservices" fashion, i.e. having (as much as possible) one container representing one logical module.
+
+## Example use-cases
+
+* __Deployment on drones:__ one could have `px4-posix-mavros` and a ROS module deriving from `px4-posix-ros-base` running on an Intel Aero.
+* __Continuous integration:__ the system could run the tested code against fixed containers (SITL, Mavros, ...), ensuring that those containers don't change between different runs.
+* __Development:__ a developer working on a specific ROS module could just run his simulation in a container, mavros in another one, and his ROS nodes directly on his machine. This way she would not have to care about maintaining a working simulation environment.
+* __Quick start guide:__ a new developer can just run a set of containers and enjoy the simulation without having to go through the pain of installing the full system.
+
+# Hierarchy
+
+The containers are organized as follows. Containers listed in bold are already implemented, others are just suggestions for further development.
+
+* __`px4-base`__
+    * __`px4-base-posix`__
+        * __`px4-posix-ros-core`__
+            * __`px4-posix-ros-base`__
+                * __`px4-posix-ros-build`__
+                    * __`px4-posix-mavros`__
+                * `px4-posix-ros-gazebo`
+                    * `px4-posix-dev-full`
+        * `px4-posix-sim`
+            * `px4-posix-gazebo`
+            * `px4-posix-jmavsim`
+    * `px4-base-nuttx`
+    * `px4-base-raspi`
+
+# Naming conventions
+
+* All container names start with the `px4-` prefix (e.g. `px4-base`)
+* Using `-dev-` in a name means that it includes development tools (in case there is a need for that). However, it is likely that developers would rather extend one of these images and build their own development image with the specific tools they use.
+
+# Folders organization
+
+* Each dockerfile is in its own directory, together with a README explaining its purpose.
+* There may be other files at the same level as the dockerfile and README, for instance resource files that need to be copied in the image.
+* There is a flat folder hierarchy between docker files (e.g. even though px4-base-posix derives from px4-base, they both have their own directory at the same level in the hierarchy).

--- a/docker/px4/px4-base-posix/Dockerfile
+++ b/docker/px4/px4-base-posix/Dockerfile
@@ -1,0 +1,1 @@
+FROM px4io/px4-base

--- a/docker/px4/px4-base-posix/README.md
+++ b/docker/px4/px4-base-posix/README.md
@@ -1,0 +1,1 @@
+This images derives from [px4-base](../px4-base) and adds elements that are shared amongst all the `px4-posix-*` images.

--- a/docker/px4/px4-base/Dockerfile
+++ b/docker/px4/px4-base/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:16.04
+
+RUN apt-get update

--- a/docker/px4/px4-base/README.md
+++ b/docker/px4/px4-base/README.md
@@ -1,0 +1,1 @@
+This image is the base for all the `px4-` images. It is based from `ubuntu:16.04` and only contains elements that are shared amongst all possible `px4-*` images.

--- a/docker/px4/px4-posix-mavros/Dockerfile
+++ b/docker/px4/px4-posix-mavros/Dockerfile
@@ -1,0 +1,25 @@
+FROM px4io/px4-posix-ros-build
+
+# Installation instructions: https://dev.px4.io/en/ros/mavros_installation.html
+
+RUN ["/bin/bash", "-c", "\
+    source /opt/ros/kinetic/setup.bash && \
+    mkdir -p ~/catkin_ws/src && \
+    catkin init --workspace ~/catkin_ws && \
+    wstool init ~/catkin_ws/src && \
+    rosinstall_generator --upstream mavros | tee /tmp/mavros.rosinstall && \
+    rosinstall_generator mavlink | tee -a /tmp/mavros.rosinstall && \
+    wstool merge -t ~/catkin_ws/src /tmp/mavros.rosinstall && \
+    wstool update -t ~/catkin_ws/src && \
+    rosdep install --from-paths ~/catkin_ws/src --ignore-src --rosdistro kinetic -y \
+"]
+
+RUN ["/bin/bash", "-c", "source /opt/ros/kinetic/setup.bash && catkin build --workspace ~/catkin_ws"]
+
+RUN ~/catkin_ws/src/mavros/mavros/scripts/install_geographiclib_datasets.sh
+
+COPY entrypoint.sh /root/entrypoint.sh
+RUN chmod +x /root/entrypoint.sh
+
+ENTRYPOINT ["/root/entrypoint.sh"]
+CMD ["fcu_url:=udp://:14540@127.0.0.1:14557"]

--- a/docker/px4/px4-posix-mavros/README.md
+++ b/docker/px4/px4-posix-mavros/README.md
@@ -1,4 +1,7 @@
 # Mavros container
+
+This image derives from [px4-posix-ros-build](../px4-posix-ros-build) and compiles mavros from sources.
+
 ## Quick start
 
 Run mavros on the default `fcu_url` (`udp://:14540@127.0.0.1:14557`) with the following command:

--- a/docker/px4/px4-posix-mavros/README.md
+++ b/docker/px4/px4-posix-mavros/README.md
@@ -1,0 +1,28 @@
+# Mavros container
+## Quick start
+
+Run mavros on the default `fcu_url` (`udp://:14540@127.0.0.1:14557`) with the following command:
+
+    $ docker run --rm -it px4-posix-mavros
+
+## Custom Mavros arguments
+
+The entrypoint of the container makes it run mavros directly with the parameters you give (default is `fcu_url:="udp://:14540@127.0.0.1:14557"`):
+
+    $ docker run --rm -it -p 11311:11311 px4io/px4-posix-mavros fcu_url:="udp://:14540@127.0.0.1:14557"
+
+## Build mavros image
+
+You can build the image yourself by cloning this repository, navigating to this folder and running:
+
+    $ docker build -t <image_name_you_want> .
+
+## More details
+
+Note that mavros starts a ROS master if it doesn't find any, which is set to run on port "11311" in the Dockerfile.
+
+Thanks to the `-p 11311:11311` part of the command above, the container binds its `11311` port to `localhost:11311` on the host. Since ROS is looking for the master locally on this port by default, it means that the host now has a ROS master running on `http://localhost:11311`. Try, for instance:
+
+    $ rostopic list
+
+This setup can be quite useful; one can for instance run ROS nodes on different containers, all set to use the mavros container as their ROS master (check the `ROS_MASTER_URI` environment variable) while at the same time running ROS nodes transparently on the host.

--- a/docker/px4/px4-posix-mavros/entrypoint.sh
+++ b/docker/px4/px4-posix-mavros/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source ~/catkin_ws/devel/setup.bash
+
+# Set ROS_IP if it is unset
+: ${ROS_IP=`hostname -I`}
+export ROS_IP
+
+# Set ROS_MASTER_URI if it is unset
+: ${ROS_MASTER_URI=http://`hostname -I`:11311}
+export ROS_MASTER_URI
+
+echo "ROS_IP: ${ROS_IP}"
+echo "ROS_MASTER_URI: ${ROS_MASTER_URI}"
+
+echo "Running \"roslaunch mavros -p 11311 px4.launch $1\""
+roslaunch mavros -p 11311 px4.launch $1

--- a/docker/px4/px4-posix-ros-base/Dockerfile
+++ b/docker/px4/px4-posix-ros-base/Dockerfile
@@ -1,0 +1,3 @@
+FROM px4io/px4-posix-ros-core
+
+RUN apt-get install -y ros-kinetic-ros-base

--- a/docker/px4/px4-posix-ros-base/README.md
+++ b/docker/px4/px4-posix-ros-base/README.md
@@ -1,0 +1,1 @@
+This images derives from [px4-posix-ros-core](../px4-posix-ros-core) and adds the `ros-kinetic-ros-base` package.

--- a/docker/px4/px4-posix-ros-build/Dockerfile
+++ b/docker/px4/px4-posix-ros-build/Dockerfile
@@ -1,0 +1,12 @@
+FROM px4io/px4-posix-ros-base
+
+RUN apt-get update && \
+    apt-get install -y python-wstool \
+                       python-rosinstall-generator \
+                       python-catkin-tools
+
+RUN ["/bin/bash", "-c", " \
+    source /opt/ros/kinetic/setup.bash && \
+    rosdep init && \
+    rosdep update \
+"]

--- a/docker/px4/px4-posix-ros-build/README.md
+++ b/docker/px4/px4-posix-ros-build/README.md
@@ -1,0 +1,1 @@
+This images derives from [px4-posix-ros-base](../px4-posix-ros-base) and adds prerequisites for building ROS packages.

--- a/docker/px4/px4-posix-ros-core/Dockerfile
+++ b/docker/px4/px4-posix-ros-core/Dockerfile
@@ -1,0 +1,10 @@
+FROM px4io/px4-base-posix
+
+RUN apt-get install -y lsb-release
+
+# Add ROS to sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list && \
+    apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+RUN apt-get update && \
+    apt-get install -y ros-kinetic-ros-core

--- a/docker/px4/px4-posix-ros-core/README.md
+++ b/docker/px4/px4-posix-ros-core/README.md
@@ -1,0 +1,1 @@
+This image derives from [px4-base-posix](../px4-base-posix) and adds the ROS repositories together with the `ros-kinetic-ros-core` package.


### PR DESCRIPTION
* If this PR is accepted and there is no disagreement for it, I will setup the corresponding docker hub images.
* The only "real" image right now will be `px4-posix-mavros`, which I already use in the avoidance module.
* I am planning to add more images that I need in the avoidance module, e.g. for gazebo-ros.
* I am planning to add mode images for making a quick start section in the dev guide (e.g. showing how to use Firmware + gazebo + QGC).

Fixes #75 .