### PR TITLE
Add Arch Linux image to run tests with gcc7 and arm-none-eabi-gcc7

### DIFF
--- a/docker/px4-dev/Dockerfile_base_archlinux
+++ b/docker/px4-dev/Dockerfile_base_archlinux
@@ -1,0 +1,67 @@
+#
+# PX4 development environment based on Arch Linux
+#
+
+FROM pritunl/archlinux:2017-12-02
+MAINTAINER Julien Lecoeur <julien.lecoeur@gmail.com>
+
+RUN cat /etc/pacman.conf
+
+# Enable multilib repository
+RUN echo -e "[multilib] \nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
+
+# Install required PX4 packages
+RUN yes | pacman -Sy --noconfirm \
+		base-devel \
+		make \
+		cmake \
+		lib32-glibc \
+		git-core \
+		python-pip \
+		zip \
+		unzip \
+		vim \
+		wget \
+		arm-none-eabi-gcc \
+		arm-none-eabi-newlib
+	
+# Install genromfs
+RUN wget https://sourceforge.net/projects/romfs/files/genromfs/0.5.2/genromfs-0.5.2.tar.gz \ 
+	&& tar zxvf genromfs-0.5.2.tar.gz \
+	&& cd genromfs-0.5.2 && make && make install && cd .. \
+	&& rm genromfs-0.5.2.tar.gz genromfs-0.5.2 -r
+
+# Install python dependencies
+RUN pip install \
+		serial \
+		empy \
+		numpy \
+		toml \
+		jinja2
+
+# Install gosu
+RUN curl -sSL https://github.com/tianon/gosu/releases/download/1.8/gosu-amd64 > /usr/sbin/gosu \
+	&& chmod +x /usr/sbin/gosu 
+
+# Install yaourt
+RUN echo -e "[archlinuxfr] \nSigLevel = Never \nServer = http://repo.archlinux.fr/\$arch" >> /etc/pacman.conf \
+	&& pacman -Sy --noconfirm yaourt
+
+# Add group dialout
+RUN groupadd dialout
+
+ENV CCACHE_CPP2=1
+ENV CCACHE_MAXSIZE=1G
+ENV DISPLAY :0
+ENV PATH "/usr/lib/ccache:$PATH"
+ENV TERM=xterm
+
+# SITL UDP PORTS
+EXPOSE 14556/udp
+EXPOSE 14557/udp
+
+# create and start as LOCAL_USER_ID
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["/bin/bash"]

--- a/docker/px4-dev/Dockerfile_base_archlinux
+++ b/docker/px4-dev/Dockerfile_base_archlinux
@@ -2,53 +2,19 @@
 # PX4 development environment based on Arch Linux
 #
 
-FROM pritunl/archlinux:2017-12-02
+FROM archlinux/base:latest
 MAINTAINER Julien Lecoeur <julien.lecoeur@gmail.com>
 
-RUN cat /etc/pacman.conf
-
-# Enable multilib repository
-RUN echo -e "[multilib] \nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
-
 # Install required PX4 packages
-RUN yes | pacman -Sy --noconfirm \
-		base-devel \
-		make \
-		cmake \
-		lib32-glibc \
-		git-core \
-		python-pip \
-		zip \
-		unzip \
-		vim \
-		wget \
-		arm-none-eabi-gcc \
-		arm-none-eabi-newlib
-	
-# Install genromfs
-RUN wget https://sourceforge.net/projects/romfs/files/genromfs/0.5.2/genromfs-0.5.2.tar.gz \ 
-	&& tar zxvf genromfs-0.5.2.tar.gz \
-	&& cd genromfs-0.5.2 && make && make install && cd .. \
-	&& rm genromfs-0.5.2.tar.gz genromfs-0.5.2 -r
+COPY scripts/archlinux_install_script.sh archlinux_install_script.sh
+RUN ./archlinux_install_script.sh
 
-# Install python dependencies
-RUN pip install \
-		serial \
-		empy \
-		numpy \
-		toml \
-		jinja2
-
-# Install gosu
-RUN curl -sSL https://github.com/tianon/gosu/releases/download/1.8/gosu-amd64 > /usr/sbin/gosu \
-	&& chmod +x /usr/sbin/gosu 
-
-# Install yaourt
-RUN echo -e "[archlinuxfr] \nSigLevel = Never \nServer = http://repo.archlinux.fr/\$arch" >> /etc/pacman.conf \
-	&& pacman -Sy --noconfirm yaourt
-
-# Add group dialout
-RUN groupadd dialout
+RUN	\
+	# Install gosu
+	curl -sSL https://github.com/tianon/gosu/releases/download/1.8/gosu-amd64 > /usr/sbin/gosu \
+	&& chmod +x /usr/sbin/gosu \
+	# Add group dialout
+	&& groupadd dialout
 
 ENV CCACHE_CPP2=1
 ENV CCACHE_MAXSIZE=1G

--- a/docker/px4-dev/scripts/archlinux_install_script.sh
+++ b/docker/px4-dev/scripts/archlinux_install_script.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# From clean distribution of ArchLinux, installs 
+# all required packages for PX4 development on 
+# posix and nuttx targets
+
+# Install required PX4 packages
+yes | pacman -Sy --noconfirm \
+		base-devel \
+		make \
+		cmake \
+		git-core \
+		python-pip \
+		tar \
+        unzip \
+		vim \
+		wget \
+		zip \
+		arm-none-eabi-gcc \
+		arm-none-eabi-newlib
+
+# Install genromfs
+wget https://sourceforge.net/projects/romfs/files/genromfs/0.5.2/genromfs-0.5.2.tar.gz
+tar zxvf genromfs-0.5.2.tar.gz
+cd genromfs-0.5.2 && make && make install && cd ..
+rm genromfs-0.5.2.tar.gz genromfs-0.5.2 -r
+
+# Install python dependencies
+pip install \
+		serial \
+		empy \
+		numpy \
+		toml \
+		jinja2


### PR DESCRIPTION
The build on newer gcc versions is broken. Here is an Arch image with gcc7 and arm-none-eabi-gcc7 installed. 
I suggest to run CI on this image for posix_sitl_default, px4fmu-v2_default and px4fmu-v5_default.
@dagar 