### PR TITLE
add ROS tests dependency

### DIFF
--- a/docker/px4-dev/Dockerfile_ros
+++ b/docker/px4-dev/Dockerfile_ros
@@ -22,7 +22,7 @@ RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C3
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	# pip
-	&& pip install matplotlib numpy px4tools \
+	&& pip install matplotlib numpy px4tools pymavlink \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update


### PR DESCRIPTION
pymavlink package is used to create the mavlink message for simulating GCS heartbeat.

It is used here --> https://github.com/PX4/Firmware/blob/d3b4cd3c8ffbc956a737b5344a1841885a0d1eec/integrationtests/python_src/px4_it/mavros/mission_test.py#L55