### PR TITLE
NuttX: download gcc from https://developper.arm.com

### DIFF
--- a/docker/px4-dev/Dockerfile_nuttx
+++ b/docker/px4-dev/Dockerfile_nuttx
@@ -26,10 +26,10 @@ RUN apt-get update \
 
 # GNU Arm Embedded Toolchain: 7-2017-q4-major December 18, 2017
 RUN mkdir -p /opt/gcc && cd /opt/gcc \
-	&& wget -qO- "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2" | tar jx --strip 1 \
+	&& wget -qO- https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2 | tar jx --strip 1 \ 
 	&& rm -rf /opt/gcc/share/doc
 
-ENV PATH="$PATH:/opt/gcc/bin"
+ENV PATH="/opt/gcc/bin:$PATH"
 
 # manual ccache setup for arm-none-eabi-g++/arm-none-eabi-gcc
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/arm-none-eabi-g++ \

--- a/docker/px4-dev/Dockerfile_nuttx
+++ b/docker/px4-dev/Dockerfile_nuttx
@@ -29,7 +29,7 @@ RUN mkdir -p /opt/gcc && cd /opt/gcc \
 	&& wget -qO- https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2 | tar jx --strip 1 \ 
 	&& rm -rf /opt/gcc/share/doc
 
-ENV PATH="/opt/gcc/bin:$PATH"
+ENV PATH="$PATH:/opt/gcc/bin"
 
 # manual ccache setup for arm-none-eabi-g++/arm-none-eabi-gcc
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/arm-none-eabi-g++ \

--- a/docker/px4-dev/Makefile
+++ b/docker/px4-dev/Makefile
@@ -1,36 +1,37 @@
+TAG := $(if $(TAG),$(TAG),local)
 
 .PHONY: px4-dev-base px4-dev-nuttx px4-dev-simulation px4-dev-ros
 
 all: px4-dev-base px4-dev-nuttx px4-dev-simulation px4-dev-ros px4-dev-raspi px4-dev-armhf px4-dev-clang px4-dev-nuttx-cclang px4-dev-base-archlinux
 
 px4-dev-base:
-	docker build -t px4io/px4-dev-base . -f Dockerfile_base
+	docker build -t px4io/px4-dev-base:$(TAG) . -f Dockerfile_base
 
 px4-dev-nuttx: px4-dev-base
-	docker build -t px4io/px4-dev-nuttx . -f Dockerfile_nuttx
+	docker build -t px4io/px4-dev-nuttx:$(TAG) . -f Dockerfile_nuttx
 
 px4-dev-simulation: px4-dev-base
-	docker build -t px4io/px4-dev-simulation . -f Dockerfile_simulation
+	docker build -t px4io/px4-dev-simulation:$(TAG) . -f Dockerfile_simulation
 
 px4-dev-ros: px4-dev-simulation
-	docker build -t px4io/px4-dev-ros . -f Dockerfile_ros
+	docker build -t px4io/px4-dev-ros:$(TAG) . -f Dockerfile_ros
 
 
 px4-dev-raspi: px4-dev-base
-	docker build -t px4io/px4-dev-raspi . -f Dockerfile_raspi
+	docker build -t px4io/px4-dev-raspi:$(TAG) . -f Dockerfile_raspi
 
 px4-dev-armhf: px4-dev-base
-	docker build -t px4io/px4-dev-armhf . -f Dockerfile_armhf
+	docker build -t px4io/px4-dev-armhf:$(TAG) . -f Dockerfile_armhf
 
 
 
 px4-dev-clang: px4-dev-base
-	docker build -t px4io/px4-dev-clang . -f Dockerfile_clang
+	docker build -t px4io/px4-dev-clang:$(TAG) . -f Dockerfile_clang
 
 px4-dev-nuttx-clang: px4-dev-clang
-	docker build -t px4io/px4-dev-nuttx-clang . -f Dockerfile_nuttx_clang
+	docker build -t px4io/px4-dev-nuttx-clang:$(TAG) . -f Dockerfile_nuttx_clang
 
 
 px4-dev-base-archlinux:
-	docker build -t px4io/px4-dev-base-archlinux . -f Dockerfile_base_archlinux
+	docker build -t px4io/px4-dev-base-archlinux:$(TAG) . -f Dockerfile_base_archlinux
 


### PR DESCRIPTION
Fixes build with -Wimplicit-fallthrough enabled in https://github.com/PX4/Firmware/pull/8551