### PR TITLE
px4-dev-ros: add catkin-tools install

### DIFF
--- a/docker/px4-dev/Dockerfile_ros
+++ b/docker/px4-dev/Dockerfile_ros
@@ -13,6 +13,7 @@ RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C3
 		geographiclib-tools \
 		libgeographic-dev \
 		python-tk \
+		python-catkin-tools \
 		ros-kinetic-gazebo-ros-pkgs \
 		ros-kinetic-mavlink \
 		ros-kinetic-mavros \
@@ -26,4 +27,3 @@ RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C3
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update
-


### PR DESCRIPTION
We are missing `catkin tools` to be able to build packages using a better `catkin build` instead of `catkin_make`.
@dagar can you bring this in and tag the container? Thanks!