### PR TITLE
px4-dev-ros: upgrade python packages installed by pip

### DIFF
--- a/docker/px4-dev/Dockerfile_ros
+++ b/docker/px4-dev/Dockerfile_ros
@@ -23,7 +23,7 @@ RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C3
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	# pip
-	&& pip install matplotlib numpy px4tools pymavlink \
+	&& pip install --upgrade matplotlib numpy px4tools pymavlink \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update


### PR DESCRIPTION
This will force the upgrade of the packages and respective dependencies.