### PR TITLE
Add missing dependencies for compiling jmavsim

### DIFF
--- a/docker/px4-dev/Dockerfile_simulation
+++ b/docker/px4-dev/Dockerfile_simulation
@@ -16,6 +16,8 @@ RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add
 		libgazebo7-dev \
 		libopencv-dev \
 		libxml2-utils \
+		openjdk-8-jdk \
+		openjdk-8-jre \
 		pkg-config \
 		protobuf-compiler \
 	&& apt-get -y autoremove \


### PR DESCRIPTION
From reading the docs at: https://dev.px4.io/en/test_and_ci/docker.html I believe that the `px4-dev-simulation` docker image should be able to run jMAVSim.

px4-dev-simulation | NuttX toolchain + simulation (jMAVSim, Gazebo)
-- | --

However, the current container does not have `openjdk-8-jdk` or `openjdk-8-jre` which results in errors when trying to run `make posix jmavsim` in the container.  I got those two packages from looking at the "jMAVSim simulator dependencies" from the `ubuntu_sim_common_deps.sh` script here: https://dev.px4.io/en/setup/dev_env_linux_ubuntu.html

Thanks in advance for your feedback.  I hope this diff is useful to the community.