### PR TITLE
px4-dev-ros-kinetic: upgrade to python3 to meet matplotlib requirements

### DIFF
--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -20,6 +20,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 		protobuf-compiler \
 		python-catkin-tools \
 		python-tk \
+		python3-dev \
+		python3-pip \
 		ros-$ROS_DISTRO-gazebo-ros-pkgs \
 		ros-$ROS_DISTRO-mavlink \
 		ros-$ROS_DISTRO-mavros \
@@ -34,7 +36,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	# pip
-	&& pip install --upgrade matplotlib numpy px4tools pymavlink \
+	&& pip3 install --upgrade matplotlib numpy px4tools pymavlink \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update

--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -22,6 +22,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 		python-tk \
 		python3-dev \
 		python3-pip \
+		python3-setuptools \
 		ros-$ROS_DISTRO-gazebo-ros-pkgs \
 		ros-$ROS_DISTRO-mavlink \
 		ros-$ROS_DISTRO-mavros \

--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -19,7 +19,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 		libopencv-dev \
 		protobuf-compiler \
 		python-catkin-tools \
-		python-tk \
+		python3-tk \
 		python3-dev \
 		python3-pip \
 		python3-setuptools \


### PR DESCRIPTION
In order to fix http://ci.px4.io:8080/blue/organizations/jenkins/PX4%2Fcontainers/detail/master/22/pipeline/144