### PR TITLE
add ROS2 Crystal container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -313,6 +313,26 @@ pipeline {
             sh 'rm -rf colcon_ws'
           }
         }
+
+        stage('px4-dev-ros2-crystal') {
+          agent {
+            dockerfile {
+              filename 'Dockerfile_ros2-crystal'
+              dir 'docker/px4-dev'
+              args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
+            }
+          }
+          steps {
+            sh 'git clone --recursive https://github.com/PX4/Firmware.git colcon_ws/src/Firmware'
+            sh 'ls -l'
+            sh '''#!/bin/bash -l
+              cd colcon_ws;
+              source /opt/ros/bouncy/setup.bash;
+              colcon build --event-handlers console_direct+ --symlink-install;
+            '''
+            sh 'rm -rf colcon_ws'
+          }
+        }
       }
     }
   }

--- a/docker/px4-dev/Dockerfile_ros2-crystal
+++ b/docker/px4-dev/Dockerfile_ros2-crystal
@@ -1,0 +1,58 @@
+#
+# PX4 ROS2 development environment
+# Based from containers under https://github.com/osrf/docker_images/blob/master/ros2/bouncy/ubuntu/bionic/
+#
+
+FROM px4io/px4-dev-ros:2019-01-01
+MAINTAINER Nuno Marques <n.marques21@hotmail.com>
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV ROS1_DISTRO melodic
+ENV ROS2_DISTRO crystal
+ENV DEBIAN_FRONTEND noninteractive
+
+# setup ros2 keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \
+	&& apt-get update
+
+# install ros2 desktop and ros1-bridge
+RUN apt-get install -y --quiet \
+		ros-$ROS2_DISTRO-desktop \
+		ros-$ROS2_DISTRO-ros1-bridge \
+		ros-$ROS2_DISTRO-rmw-opensplice-cpp \
+		python3-dev \
+		python3-colcon-common-extensions \
+	&& apt-get -y autoremove \
+	&& apt-get clean autoclean \
+	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# install python packages needed for testing
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
+	&& python3 -m pip install --upgrade pip \
+		setuptools \
+		argcomplete \
+		flake8 \
+		flake8-blind-except \
+	 	flake8-builtins \
+		flake8-class-newline \
+		flake8-comprehensions \
+		flake8-deprecated \
+		flake8-docstrings \
+		flake8-import-order \
+		flake8-quotes \
+		pytest \
+		pytest-cov \
+		pytest-repeat \
+		pytest-runner \
+		pytest-rerunfailures
+
+# create and start as LOCAL_USER_ID
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
This adds a new container which installs the newly released ROS2 Crystal distro. The idea is to deprecate the Ardent container in 1 to 2 months, while the transition is being done. Ardent was officially EOF in December 18, and now Bouncy is also supported in 16.04.