### PR TITLE
ROS2 containers: remove rmw-opensplice-cpp dependency

### DIFF
--- a/docker/px4-dev/Dockerfile_ros2-ardent
+++ b/docker/px4-dev/Dockerfile_ros2-ardent
@@ -24,7 +24,6 @@ RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -
 RUN apt-get install -y --quiet \
 		ros-$ROS2_DISTRO-desktop \
 		ros-$ROS2_DISTRO-ros1-bridge \
-		ros-$ROS2_DISTRO-rmw-opensplice-cpp \
 		python3-dev \
 		python3-colcon-common-extensions \
 	&& apt-get -y autoremove \

--- a/docker/px4-dev/Dockerfile_ros2-bouncy
+++ b/docker/px4-dev/Dockerfile_ros2-bouncy
@@ -24,7 +24,6 @@ RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -
 RUN apt-get install -y --quiet \
 		ros-$ROS2_DISTRO-desktop \
 		ros-$ROS2_DISTRO-ros1-bridge \
-		ros-$ROS2_DISTRO-rmw-opensplice-cpp \
 		python3-dev \
 		python3-colcon-common-extensions \
 	&& apt-get -y autoremove \

--- a/docker/px4-dev/Dockerfile_ros2-crystal
+++ b/docker/px4-dev/Dockerfile_ros2-crystal
@@ -24,7 +24,6 @@ RUN echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -
 RUN apt-get install -y --quiet \
 		ros-$ROS2_DISTRO-desktop \
 		ros-$ROS2_DISTRO-ros1-bridge \
-		ros-$ROS2_DISTRO-rmw-opensplice-cpp \
 		python3-dev \
 		python3-colcon-common-extensions \
 	&& apt-get -y autoremove \


### PR DESCRIPTION
Not needed anymore with the changes on the `px4_ros_com` build structure.