### PR TITLE
Dockerfile_ros-kinetic: gazebo8, xvfb

### DIFF
--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -37,7 +37,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 		ros-$ROS_DISTRO-rosunit \
 		ros-$ROS_DISTRO-xacro \
 		xvfb \
-		sudo \
 	&& geographiclib-get-geoids egm96-5 \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
@@ -47,10 +46,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 
 RUN rosdep init && rosdep update
 
-
 # create and start as LOCAL_USER_ID
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-
 
 CMD ["/bin/bash"]

--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -47,11 +47,10 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 
 RUN rosdep init && rosdep update
 
-RUN useradd -m user && echo "user:user" | chpasswd && adduser user sudo
-
 
 # create and start as LOCAL_USER_ID
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
 
 CMD ["/bin/bash"]

--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -11,6 +11,8 @@ ENV ROS_DISTRO kinetic
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116 \
 	&& sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list' \
 	&& sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-shadow.list' \
+	&& sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' \
+	&& wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - \
 	&& apt-get update \
 	&& apt-get -y --quiet --no-install-recommends install \
 		geographiclib-tools \
@@ -23,7 +25,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 		python3-dev \
 		python3-pip \
 		python3-setuptools \
-		ros-$ROS_DISTRO-gazebo-ros-pkgs \
+		ros-$ROS_DISTRO-gazebo8-ros-pkgs \
 		ros-$ROS_DISTRO-mavlink \
 		ros-$ROS_DISTRO-mavros \
 		ros-$ROS_DISTRO-mavros-extras \
@@ -34,6 +36,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 		ros-$ROS_DISTRO-rostest \
 		ros-$ROS_DISTRO-rosunit \
 		ros-$ROS_DISTRO-xacro \
+		xvfb \
+		sudo \
 	&& geographiclib-get-geoids egm96-5 \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
@@ -42,6 +46,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update
+
+RUN useradd -m user && echo "user:user" | chpasswd && adduser user sudo
+
 
 # create and start as LOCAL_USER_ID
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/docker/px4-dev/scripts/entrypoint.sh
+++ b/docker/px4-dev/scripts/entrypoint.sh
@@ -9,6 +9,7 @@ USER_ID=${LOCAL_USER_ID:-9001}
 echo "Starting with UID : $USER_ID"
 useradd --shell /bin/bash -u $USER_ID -o -c "" -m user
 usermod -a -G dialout user
+usermod -a -G sudo user
 
 if [ -d "$CCACHE_DIR" ]; then
 	chown -R $USER_ID $CCACHE_DIR


### PR DESCRIPTION
With the current container, simulate cameras end up in a boost pointer exception (https://github.com/PX4/Firmware/pull/10780) . 
To run the camera headlessly I can run a xvfb server but it only works with Gazebo8 and not Gazebo7. 
I cannot make xvfb work without sudo inside the container. 