### PR TITLE
Base px4-dev-ros from px4-dev-simulation (Ubuntu 18.04)

### DIFF
--- a/docker/px4-dev/Dockerfile_armhf
+++ b/docker/px4-dev/Dockerfile_armhf
@@ -7,7 +7,7 @@
 # Parrot Bebop, or OcPoC-Zynq
 #
 
-FROM px4io/px4-dev-base:2019-01-01
+FROM px4io/px4-dev-base:2019-01-14
 
 RUN apt-get update && apt-get -yy --quiet --no-install-recommends install \
 		g++-arm-linux-gnueabihf \

--- a/docker/px4-dev/Dockerfile_clang
+++ b/docker/px4-dev/Dockerfile_clang
@@ -3,7 +3,7 @@
 #  px4-dev-base + latest clang
 #
 
-FROM px4io/px4-dev-base:2019-01-01
+FROM px4io/px4-dev-base:2019-01-14
 MAINTAINER Daniel Agar <daniel@agar.ca>
 
 RUN wget --quiet http://apt.llvm.org/llvm-snapshot.gpg.key -O - | apt-key add - \

--- a/docker/px4-dev/Dockerfile_ecl
+++ b/docker/px4-dev/Dockerfile_ecl
@@ -2,7 +2,7 @@
 # PX4 ecl build and test development environment
 #
 
-FROM px4io/px4-dev-base:2019-01-01
+FROM px4io/px4-dev-base:2019-01-14
 MAINTAINER Daniel Agar <daniel@agar.ca>
 
 RUN apt-get update \

--- a/docker/px4-dev/Dockerfile_nuttx
+++ b/docker/px4-dev/Dockerfile_nuttx
@@ -2,7 +2,7 @@
 # PX4 NuttX development environment
 #
 
-FROM px4io/px4-dev-base:2019-01-01
+FROM px4io/px4-dev-base:2019-01-14
 MAINTAINER Daniel Agar <daniel@agar.ca>
 
 RUN apt-get update \

--- a/docker/px4-dev/Dockerfile_nuttx_clang
+++ b/docker/px4-dev/Dockerfile_nuttx_clang
@@ -2,7 +2,7 @@
 # PX4 Clang + NuttX development environment
 #
 
-FROM px4io/px4-dev-clang:2019-01-01
+FROM px4io/px4-dev-clang:2019-01-14
 
 RUN dpkg --add-architecture i386 \
 	&& apt-get update \

--- a/docker/px4-dev/Dockerfile_raspi
+++ b/docker/px4-dev/Dockerfile_raspi
@@ -5,7 +5,7 @@
 # Raspberry Pi or Parrot Bebop
 #
 
-FROM px4io/px4-dev-base:2019-01-01
+FROM px4io/px4-dev-base:2019-01-14
 MAINTAINER Michael Schaeuble
 
 RUN apt-get update \

--- a/docker/px4-dev/Dockerfile_ros
+++ b/docker/px4-dev/Dockerfile_ros
@@ -2,7 +2,7 @@
 # PX4 ROS development environment
 #
 
-FROM px4io/px4-dev-simulation:2019-01-01
+FROM px4io/px4-dev-simulation:2019-01-14
 MAINTAINER Daniel Agar <daniel@agar.ca>
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/px4-dev/Dockerfile_ros
+++ b/docker/px4-dev/Dockerfile_ros
@@ -17,7 +17,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 		libeigen3-dev \
 		libgeographic-dev \
 		libopencv-dev \
-		protobuf-compiler \
 		python-catkin-tools \
 		python-tk \
 		ros-$ROS_DISTRO-gazebo-ros-pkgs \

--- a/docker/px4-dev/Dockerfile_ros
+++ b/docker/px4-dev/Dockerfile_ros
@@ -2,7 +2,7 @@
 # PX4 ROS development environment
 #
 
-FROM px4io/px4-dev-base:2019-01-01
+FROM px4io/px4-dev-simulation:2019-01-01
 MAINTAINER Daniel Agar <daniel@agar.ca>
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/px4-dev/Dockerfile_ros2-bouncy
+++ b/docker/px4-dev/Dockerfile_ros2-bouncy
@@ -3,7 +3,7 @@
 # Based from containers under https://github.com/osrf/docker_images/blob/master/ros2/bouncy/ubuntu/bionic/
 #
 
-FROM px4io/px4-dev-ros:2019-01-01
+FROM px4io/px4-dev-ros:2019-01-14
 MAINTAINER Nuno Marques <n.marques21@hotmail.com>
 
 # setup environment

--- a/docker/px4-dev/Dockerfile_ros2-crystal
+++ b/docker/px4-dev/Dockerfile_ros2-crystal
@@ -3,7 +3,7 @@
 # Based from containers under https://github.com/osrf/docker_images/blob/master/ros2/bouncy/ubuntu/bionic/
 #
 
-FROM px4io/px4-dev-ros:2019-01-01
+FROM px4io/px4-dev-ros:2019-01-14
 MAINTAINER Nuno Marques <n.marques21@hotmail.com>
 
 # setup environment

--- a/docker/px4-dev/Dockerfile_simulation
+++ b/docker/px4-dev/Dockerfile_simulation
@@ -2,7 +2,7 @@
 # PX4 gazebo development environment
 #
 
-FROM px4io/px4-dev-base:2019-01-01
+FROM px4io/px4-dev-base:2019-01-14
 MAINTAINER Daniel Agar <daniel@agar.ca>
 
 RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - \


### PR DESCRIPTION
It does not make much sense to have the ROS containers independent of the simulation ones, specially when one pretends to use them for testing ROS routines/missions in the simulation environment.