### PR TITLE
Add xacro to Dockerfile

### DIFF
--- a/docker/px4-dev/Dockerfile_ros
+++ b/docker/px4-dev/Dockerfile_ros
@@ -29,6 +29,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 		ros-$ROS_DISTRO-ros-base \
 		ros-$ROS_DISTRO-rostest \
 		ros-$ROS_DISTRO-rosunit \
+		ros-$ROS_DISTRO-xacro \
 	&& geographiclib-get-geoids egm96-5 \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \

--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -33,6 +33,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 		ros-$ROS_DISTRO-ros-base \
 		ros-$ROS_DISTRO-rostest \
 		ros-$ROS_DISTRO-rosunit \
+		ros-$ROS_DISTRO-xacro \
 	&& geographiclib-get-geoids egm96-5 \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \


### PR DESCRIPTION
xacro is required for the [Multi-Vehicle Simulation with gazebo](https://dev.px4.io/en/simulation/multi-vehicle-simulation.html). So it would be better to install xacro in px4-dev-ros.