### PR TITLE
entrypoint: run xvfb if ROS_DISTRO is melodic

### DIFF
--- a/docker/px4-dev/scripts/entrypoint.sh
+++ b/docker/px4-dev/scripts/entrypoint.sh
@@ -4,6 +4,11 @@
 # Either use the LOCAL_USER_ID if passed in at runtime or
 # fallback
 
+if [ "${ROS_DISTRO}" == "melodic" ]; then
+	export DISPLAY=:0
+	Xvfb :1 -screen 0 1600x1200x24+32 &
+fi
+
 if [ -n "${LOCAL_USER_ID}" ]; then
 
 	echo "Starting with UID : $LOCAL_USER_ID"


### PR DESCRIPTION
Hacky solution to run xvfb. 
It's needed because we cannot launch xvfb with the Firmware test script due to permission error:

```bash
+ px4-px4_sitl_default-v1.9.0-beta1-36-ga74bb362c/px4/test/rostest_avoidance_run.sh mavros_posix_test_avoidance.test mission:=avoidance vehicle:=iris_obs_avoid
_XSERVTransmkdir: ERROR: euid != 0,directory /tmp/.X11-unix will not be created
```