### PR TITLE
entrypoint: Use Xvfb

### DIFF
--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -22,7 +22,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 		protobuf-compiler \
 		python-catkin-tools \
 		python-tk \
-		ros-$ROS_DISTRO-gazebo8-ros-pkgs \
+		ros-$ROS_DISTRO-gazebo-ros-pkgs \
 		ros-$ROS_DISTRO-mavlink \
 		ros-$ROS_DISTRO-mavros \
 		ros-$ROS_DISTRO-mavros-extras \

--- a/docker/px4-dev/scripts/entrypoint.sh
+++ b/docker/px4-dev/scripts/entrypoint.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Start virtual X server in the background if there is no display
+if [ -z "$DISPLAY" ]; then
+	echo "Starting Xvfb"
+	Xvfb :99 -screen 0 1600x1200x24+32 &
+	export DISPLAY=:99
+fi
+
 # Add local user
 # Either use the LOCAL_USER_ID if passed in at runtime or
 # fallback


### PR DESCRIPTION
If the display isn't specified, such as `-e DISPLAY=:0` detailed in the README, run the virtual X server.

This is required to simulate cameras in SITL tests in Jenkins. Will be needed for https://github.com/PX4/Firmware/pull/10780 and will hopefully address https://github.com/PX4/Firmware/issues/11257 as the FW model has a camera.

Testing details are here https://github.com/PX4/Firmware/pull/10780#issuecomment-458702060.

Supersedes: https://github.com/PX4/containers/pull/166