### PR TITLE
base: split out a ubuntu 16 version

### DIFF
--- a/docker/px4-dev/Dockerfile_base-xenial
+++ b/docker/px4-dev/Dockerfile_base-xenial
@@ -1,0 +1,98 @@
+#
+# PX4 base development environment
+#
+
+FROM ubuntu:16.04
+MAINTAINER Daniel Agar <daniel@agar.ca>
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
+		bzip2 \
+		ca-certificates \
+		ccache \
+		cmake \
+		cppcheck \
+		curl \
+		dirmngr \
+		doxygen \
+		file \
+		g++ \
+		gcc \
+		gdb \
+		git \
+		gnupg \
+		gosu \
+		lcov \
+		libfreetype6-dev \
+		libgtest-dev \
+		libpng-dev \
+		lsb-release \
+		make \
+		ninja-build \
+		openjdk-8-jdk \
+		openjdk-8-jre \
+		openssh-client \
+		pkg-config \
+		python-pip \
+		python-pygments \
+		python-setuptools \
+		rsync \
+		shellcheck \
+		tzdata \
+		unzip \
+		wget \
+		xsltproc \
+		zip \
+	&& apt-get -y autoremove \
+	&& apt-get clean autoclean \
+	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# gtest
+RUN cd /usr/src/gtest \
+	&& mkdir build && cd build \
+	&& cmake .. && make \
+	&& cp *.a /usr/lib \
+	&& cd .. && rm -rf build
+
+RUN python -m pip install --upgrade pip \
+	&& pip install setuptools pkgconfig wheel \
+	&& pip install argparse argcomplete coverage jinja2 empy numpy requests serial toml pyyaml cerberus
+
+# manual ccache setup
+RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \
+	&& ln -s /usr/bin/ccache /usr/lib/ccache/c++
+
+# astyle v2.06
+RUN wget -q https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.06/astyle_2.06_linux.tar.gz -O /tmp/astyle.tar.gz \
+	&& cd /tmp && tar zxf astyle.tar.gz && cd astyle/src \
+	&& make -f ../build/gcc/Makefile && cp bin/astyle /usr/local/bin \
+	&& rm -rf /tmp/*
+
+# Fast-RTPS
+RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-6-0/eprosima_fastrtps-1-6-0-linux-tar-gz?format=raw" -O /tmp/eprosima_fastrtps.tar.gz \
+	&& cd /tmp && tar zxf eprosima_fastrtps.tar.gz \
+	&& mkdir -p /usr/local/share/fastrtps \
+	&& cp eProsima_FastRTPS-1.6.0-Linux/share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/fastrtpsgen.jar \
+	&& cp eProsima_FastRTPS-1.6.0-Linux/bin/fastrtpsgen /usr/local/bin/fastrtpsgen \
+	&& rm -rf /tmp/*
+
+
+# create user with id 1001 (jenkins docker workflow default)
+RUN useradd --shell /bin/bash -u 1001 -c "" -m user && usermod -a -G dialout user
+
+ENV CCACHE_UMASK=000
+ENV FASTRTPSGEN_DIR="/usr/local/bin/"
+ENV PATH="/usr/lib/ccache:$PATH"
+ENV TERM=xterm
+ENV TZ=UTC
+
+# SITL UDP PORTS
+EXPOSE 14556/udp
+EXPOSE 14557/udp
+
+# create and start as LOCAL_USER_ID
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["/bin/bash"]

--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -2,7 +2,7 @@
 # PX4 ROS development environment
 #
 
-FROM px4io/px4-dev-base:ubuntu16.04
+FROM px4io/px4-dev-base-xenial:pr-base-ubuntu16
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/px4-dev/Makefile
+++ b/docker/px4-dev/Makefile
@@ -1,10 +1,13 @@
 
-.PHONY: px4-dev-base px4-dev-nuttx px4-dev-simulation px4-dev-ros px4-dev-ros-kinetic px4-dev-ecl px4-dev-raspi px4-dev-armhf px4-dev-clang px4-dev-nuttx-clang px4-dev-base-archlinux
+.PHONY: px4-dev-base px4-dev-base-xenial px4-dev-nuttx px4-dev-simulation px4-dev-ros px4-dev-ros-kinetic px4-dev-ecl px4-dev-raspi px4-dev-armhf px4-dev-clang px4-dev-nuttx-clang px4-dev-base-archlinux
 
-all: px4-dev-base px4-dev-nuttx px4-dev-simulation px4-dev-ros px4-dev-ros-kinetic px4-dev-ecl px4-dev-raspi px4-dev-armhf px4-dev-clang px4-dev-nuttx-clang px4-dev-base-archlinux
+all: px4-dev-base px4-dev-base-xenial px4-dev-nuttx px4-dev-simulation px4-dev-ros px4-dev-ros-kinetic px4-dev-ecl px4-dev-raspi px4-dev-armhf px4-dev-clang px4-dev-nuttx-clang px4-dev-base-archlinux
 
 px4-dev-base:
 	docker build -t px4io/px4-dev-base . -f Dockerfile_base
+
+px4-dev-base-xenial:
+	docker build -t px4io/px4-dev-base-xenial . -f Dockerfile_base-xenial
 
 px4-dev-nuttx: px4-dev-base
 	docker build -t px4io/px4-dev-nuttx . -f Dockerfile_nuttx
@@ -21,21 +24,17 @@ px4-dev-ros-kinetic:
 px4-dev-ecl: px4-dev-base
 	docker build -t px4io/px4-dev-ecl . -f Dockerfile_ecl
 
-
 px4-dev-raspi: px4-dev-base
 	docker build -t px4io/px4-dev-raspi . -f Dockerfile_raspi
 
 px4-dev-armhf: px4-dev-base
 	docker build -t px4io/px4-dev-armhf . -f Dockerfile_armhf
 
-
-
 px4-dev-clang: px4-dev-base
 	docker build -t px4io/px4-dev-clang . -f Dockerfile_clang
 
 px4-dev-nuttx-clang: px4-dev-clang
 	docker build -t px4io/px4-dev-nuttx-clang . -f Dockerfile_nuttx_clang
-
 
 px4-dev-base-archlinux:
 	docker build -t px4io/px4-dev-base-archlinux . -f Dockerfile_base_archlinux


### PR DESCRIPTION
We need this to update the ros-kinetic container. Solves entrypoint, user and xvfb issues.

I added it to docker hub: https://hub.docker.com/r/px4io/px4-dev-base-xenial