### PR TITLE
px4-dev-ros-kinetic: add matplotlib dependency for python3

### DIFF
--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -41,7 +41,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 	# pip
 	&& pip install --upgrade numpy px4tools pymavlink \
 	&& pip3 install --upgrade setuptools wheel \
-	&& pip3 install --upgrade pyulog \
+	&& pip3 install --upgrade pyulog matplotlib \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update


### PR DESCRIPTION
this pull request installs matplotlib for python3 which is required for PX4 Firmware pull request [#11412](https://github.com/PX4/Firmware/pull/11412).