### PR TITLE
fix xvfb

### DIFF
--- a/docker/px4-dev/Dockerfile_base-bionic
+++ b/docker/px4-dev/Dockerfile_base-bionic
@@ -80,6 +80,12 @@ RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima
 # create user with id 1001 (jenkins docker workflow default)
 RUN useradd --shell /bin/bash -u 1001 -c "" -m user && usermod -a -G dialout user
 
+# setup virtual X server
+RUN mkdir /tmp/.X11-unix && \
+	chmod 1777 /tmp/.X11-unix && \
+	chown -R root:root /tmp/.X11-unix
+ENV DISPLAY :99
+
 ENV CCACHE_UMASK=000
 ENV FASTRTPSGEN_DIR="/usr/local/bin/"
 ENV PATH="/usr/lib/ccache:$PATH"

--- a/docker/px4-dev/Dockerfile_base-xenial
+++ b/docker/px4-dev/Dockerfile_base-xenial
@@ -81,6 +81,12 @@ RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima
 # create user with id 1001 (jenkins docker workflow default)
 RUN useradd --shell /bin/bash -u 1001 -c "" -m user && usermod -a -G dialout user
 
+# setup virtual X server
+RUN mkdir /tmp/.X11-unix && \
+	chmod 1777 /tmp/.X11-unix && \
+	chown -R root:root /tmp/.X11-unix
+ENV DISPLAY :99
+
 ENV CCACHE_UMASK=000
 ENV FASTRTPSGEN_DIR="/usr/local/bin/"
 ENV PATH="/usr/lib/ccache:$PATH"

--- a/docker/px4-dev/scripts/entrypoint.sh
+++ b/docker/px4-dev/scripts/entrypoint.sh
@@ -1,26 +1,21 @@
 #!/bin/bash
 
-# Start virtual X server in the background if there is no display
-if [[ -x "$(command -v Xvfb)" && -z "$DISPLAY" ]]; then
-	echo "Starting Xvfb"
+# Start virtual X server in the background
+# - DISPLAY default is :99, set in dockerfile
+# - Users can override with `-e DISPLAY=` in `docker run` command to avoid 
+#   running Xvfb and attach their screen
+if [[ -x "$(command -v Xvfb)" && "$DISPLAY" == ":99" ]]; then
+	echo "Starting Xvfb" 
 	Xvfb :99 -screen 0 1600x1200x24+32 &
-	export DISPLAY=:99
 fi
 
-# Add local user
-# Either use the LOCAL_USER_ID if passed in at runtime or
-# fallback
-
+# Use the LOCAL_USER_ID if passed in at runtime
 if [ -n "${LOCAL_USER_ID}" ]; then
-
 	echo "Starting with UID : $LOCAL_USER_ID"
-
 	# modify existing user's id
 	usermod -u $LOCAL_USER_ID user
-
+	# run as user
 	exec gosu user "$@"
-
 else
-
 	exec "$@"
 fi


### PR DESCRIPTION
- set default DISPLAY=:99 in dockerfile
- run Xvfb from entrypoint if DISPLAY is the default :99
- create X11 tmp dir for Xvfb in dockerfile

This aims to fix https://github.com/PX4/Firmware/issues/11523 where we were still seeing:
```
[Err] [RenderEngine.cc:734] Can't open display: 
[Wrn] [RenderEngine.cc:97] Unable to create X window. Rendering will be disabled
[Wrn] [RenderEngine.cc:301] Cannot initialize render engine since render path type is NONE. Ignore this warning ifrendering has been turned off on purpose.
```
for the Gazebo based simulation tests.

The permission issues were from trying to create the `/tmp/.X11-unix` directory at runtime for Xvfb. So it is now done ahead of time in the Dockerfile.

Additionally, the `DISPLAY` variable set in the `entrypoint` didn't persist across the `sh`  pipeline steps. Setting it up this way (how the `DISPLAY` environment variable is handled) allows for users to override it (per the [README](https://github.com/PX4/containers/blob/master/docker/px4-dev/README.md)) in order to use their screen and not launch Xvfb, but by default Xvfb will be used. This means it will be used by Jenkins, without any modifications to the Jenkinsfiles in the Firmware repo.

To test this: I built `base-xenial` with these changes (overwriting the `latest` tag) locally. Then I built `ros-kinetic` (overwriting `2019-02-14`). On the same local machine with Jenkins setup on my Firmware fork (synced with upstream/master) I ran the SITL job. This used the newly built images as defined with this PR. The errors above were gone. I could also see Xvfb running with `ps -A`  when I used `docker exec -it <container> bash` to get into a container while Jenkins was running the job. This of course means that the error from Xvfb was also gone that was seen when running `docker logs <container>`.