### PR TITLE
docker: add container variants without ninja-build

### DIFF
--- a/docker/px4-dev/Dockerfile_base-bionic-noninja
+++ b/docker/px4-dev/Dockerfile_base-bionic-noninja
@@ -1,0 +1,8 @@
+#
+# PX4 base development environment without ninja to use "Unix Makefiles" as the generator.
+#
+
+FROM px4io/px4-dev-base-bionic:2019-03-08
+LABEL maintainer="Julian Oes <daniel@agar.ca>"
+
+RUN apt-get -y purge ninja-build

--- a/docker/px4-dev/Dockerfile_nuttx_noninja
+++ b/docker/px4-dev/Dockerfile_nuttx_noninja
@@ -1,0 +1,8 @@
+#
+# PX4 NuttX development environment without ninja to use "Unix Makefiles" as the generator.
+#
+
+FROM px4io/px4-dev-nuttx:2019-03-08
+LABEL maintainer="Julian Oes <julian@oes.ch>"
+
+RUN apt-get -y purge ninja-build


### PR DESCRIPTION
We should also build without ninja-build in order not to break the build with "Unix Makefiles" as the cmake generator.