### PR TITLE
Fast-RTPS: bump to 1.7.2 and add to ArchLinux

### DIFF
--- a/docker/px4-dev/Dockerfile_base-archlinux
+++ b/docker/px4-dev/Dockerfile_base-archlinux
@@ -44,11 +44,11 @@ RUN	curl -sSL https://github.com/tianon/gosu/releases/download/1.8/gosu-amd64 > 
 	&& chmod +x /usr/sbin/gosu
 
 # Install Fast-RTPS
-RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-7-2/eprosima_fastrtps-1-7-2-linux-tar-gz?format=raw" -O /tmp/eprosima_fastrtps.tar.gz \
-	&& cd /tmp && tar zxf eprosima_fastrtps.tar.gz \
-	&& mkdir -p /usr/local/share/fastrtps \
-	&& cp eProsima_FastRTPS-1.7.2-Linux/share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/fastrtpsgen.jar \
-	&& cp eProsima_FastRTPS-1.7.2-Linux/bin/fastrtpsgen /usr/local/bin/fastrtpsgen \
+RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b release/1.7.2 /tmp/Fast-RTPS-1.7.2
+	&& cd /tmp/Fast-RTPS-1.7.2 \
+	&& mkdir build && cd build \
+	&& cmake -DTHIRDPARTY=ON -DBUILD_JAVA=ON .. \
+	&& make && sudo make install \
 	&& rm -rf /tmp/*
 
 # Add group dialout

--- a/docker/px4-dev/Dockerfile_base-archlinux
+++ b/docker/px4-dev/Dockerfile_base-archlinux
@@ -43,12 +43,21 @@ RUN	wget https://sourceforge.net/projects/romfs/files/genromfs/0.5.2/genromfs-0.
 RUN	curl -sSL https://github.com/tianon/gosu/releases/download/1.8/gosu-amd64 > /usr/sbin/gosu \
 	&& chmod +x /usr/sbin/gosu
 
+# Gradle (Required to build Fast-RTPS)
+RUN wget -q "https://services.gradle.org/distributions/gradle-5.4.1-bin.zip" -O /tmp/gradle-5.4.1-bin.zip \
+	&& mkdir /opt/gradle \
+	&& cd /tmp \
+	&& unzip -d /opt/gradle gradle-5.4.1-bin.zip \
+	&& rm -rf /tmp/*
+
+ENV PATH "/opt/gradle/gradle-5.4.1/bin:$PATH"
+
 # Install Fast-RTPS
 RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b release/1.7.2 /tmp/Fast-RTPS-1.7.2
 	&& cd /tmp/Fast-RTPS-1.7.2 \
 	&& mkdir build && cd build \
 	&& cmake -DTHIRDPARTY=ON -DBUILD_JAVA=ON .. \
-	&& make && sudo make install \
+	&& make && make install \
 	&& rm -rf /tmp/*
 
 # Add group dialout

--- a/docker/px4-dev/Dockerfile_base-archlinux
+++ b/docker/px4-dev/Dockerfile_base-archlinux
@@ -43,6 +43,14 @@ RUN	wget https://sourceforge.net/projects/romfs/files/genromfs/0.5.2/genromfs-0.
 RUN	curl -sSL https://github.com/tianon/gosu/releases/download/1.8/gosu-amd64 > /usr/sbin/gosu \
 	&& chmod +x /usr/sbin/gosu
 
+# Install Fast-RTPS
+RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-7-2/eprosima_fastrtps-1-7-2-linux-tar-gz?format=raw" -O /tmp/eprosima_fastrtps.tar.gz \
+	&& cd /tmp && tar zxf eprosima_fastrtps.tar.gz \
+	&& mkdir -p /usr/local/share/fastrtps \
+	&& cp eProsima_FastRTPS-1.7.2-Linux/share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/fastrtpsgen.jar \
+	&& cp eProsima_FastRTPS-1.7.2-Linux/bin/fastrtpsgen /usr/local/bin/fastrtpsgen \
+	&& rm -rf /tmp/*
+
 # Add group dialout
 RUN	groupadd dialout
 
@@ -51,6 +59,7 @@ RUN	ln -s /usr/bin/ccache /usr/lib/ccache/bin/arm-none-eabi-gcc \
 	&& ln -s /usr/bin/ccache /usr/lib/ccache/bin/arm-none-eabi-g++
 
 ENV CCACHE_MAXSIZE=1G
+ENV FASTRTPSGEN_DIR="/usr/local/bin/"
 ENV PATH "/usr/lib/ccache/bin:$PATH"
 ENV TERM=xterm
 

--- a/docker/px4-dev/Dockerfile_base-bionic
+++ b/docker/px4-dev/Dockerfile_base-bionic
@@ -70,11 +70,11 @@ RUN wget -q https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.0
 	&& rm -rf /tmp/*
 
 # Fast-RTPS
-RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-7-2/eprosima_fastrtps-1-7-2-linux-tar-gz?format=raw" -O /tmp/eprosima_fastrtps.tar.gz \
-	&& cd /tmp && tar zxf eprosima_fastrtps.tar.gz \
-	&& mkdir -p /usr/local/share/fastrtps \
-	&& cp eProsima_FastRTPS-1.7.2-Linux/share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/fastrtpsgen.jar \
-	&& cp eProsima_FastRTPS-1.7.2-Linux/bin/fastrtpsgen /usr/local/bin/fastrtpsgen \
+RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b release/1.7.2 /tmp/Fast-RTPS-1.7.2 \
+	&& cd /tmp/Fast-RTPS-1.7.2 \
+	&& mkdir build && cd build \
+	&& cmake -DTHIRDPARTY=ON -DBUILD_JAVA=ON .. \
+	&& make && sudo make install \
 	&& rm -rf /tmp/*
 
 # create user with id 1001 (jenkins docker workflow default)

--- a/docker/px4-dev/Dockerfile_base-bionic
+++ b/docker/px4-dev/Dockerfile_base-bionic
@@ -70,11 +70,11 @@ RUN wget -q https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.0
 	&& rm -rf /tmp/*
 
 # Fast-RTPS
-RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-6-0/eprosima_fastrtps-1-6-0-linux-tar-gz?format=raw" -O /tmp/eprosima_fastrtps.tar.gz \
+RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-7-2/eprosima_fastrtps-1-7-2-linux-tar-gz?format=raw" -O /tmp/eprosima_fastrtps.tar.gz \
 	&& cd /tmp && tar zxf eprosima_fastrtps.tar.gz \
 	&& mkdir -p /usr/local/share/fastrtps \
-	&& cp eProsima_FastRTPS-1.6.0-Linux/share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/fastrtpsgen.jar \
-	&& cp eProsima_FastRTPS-1.6.0-Linux/bin/fastrtpsgen /usr/local/bin/fastrtpsgen \
+	&& cp eProsima_FastRTPS-1.7.2-Linux/share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/fastrtpsgen.jar \
+	&& cp eProsima_FastRTPS-1.7.2-Linux/bin/fastrtpsgen /usr/local/bin/fastrtpsgen \
 	&& rm -rf /tmp/*
 
 # create user with id 1001 (jenkins docker workflow default)

--- a/docker/px4-dev/Dockerfile_base-bionic
+++ b/docker/px4-dev/Dockerfile_base-bionic
@@ -69,12 +69,21 @@ RUN wget -q https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.0
 	&& make -f ../build/gcc/Makefile && cp bin/astyle /usr/local/bin \
 	&& rm -rf /tmp/*
 
+# Gradle (Required to build Fast-RTPS)
+RUN wget -q "https://services.gradle.org/distributions/gradle-5.4.1-bin.zip" -O /tmp/gradle-5.4.1-bin.zip \
+	&& mkdir /opt/gradle \
+	&& cd /tmp \
+	&& unzip -d /opt/gradle gradle-5.4.1-bin.zip \
+	&& rm -rf /tmp/*
+
+ENV PATH "/opt/gradle/gradle-5.4.1/bin:$PATH"
+
 # Fast-RTPS
 RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b release/1.7.2 /tmp/Fast-RTPS-1.7.2 \
 	&& cd /tmp/Fast-RTPS-1.7.2 \
 	&& mkdir build && cd build \
 	&& cmake -DTHIRDPARTY=ON -DBUILD_JAVA=ON .. \
-	&& make && sudo make install \
+	&& make && make install \
 	&& rm -rf /tmp/*
 
 # create user with id 1001 (jenkins docker workflow default)


### PR DESCRIPTION
This PR bumps Fast-RTPS version to 1.7.2 on Ubuntu 18.04, since it's the default compatible version with ROS 2 Crystal. Besides that, I add the install of this to ArchLinux as well, so anyone using and developing under ArchLinux and wanting to use these containers also is able to use Fast-RTPS.

@julianoes can I have your review on the ArchLinux side? Thanks!