### PR TITLE
ROS2 containers: install python3-genmsg and python3-gencpp from deb sources

### DIFF
--- a/docker/px4-dev/Dockerfile_ros2-ardent
+++ b/docker/px4-dev/Dockerfile_ros2-ardent
@@ -50,3 +50,18 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 		pytest-repeat \
 		pytest-runner \
 		pytest-rerunfailures
+
+# Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
+RUN apt-get install -y --quiet python3-genmsg \
+	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.11-2_all.deb -P /tmp/ \
+		&& dpkg -i /tmp/python3-genmsg_0.5.11-2_all.deb \
+		&& apt-get -y autoremove \
+		&& apt-get clean autoclean \
+		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+RUN apt-get install -y --quiet python3-gencpp \
+	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-gencpp/python3-gencpp_0.6.0-4_all.deb -P /tmp/ \
+		&& dpkg -i /tmp/python3-gencpp_0.6.0-4_all.deb \
+		&& apt-get -y autoremove \
+		&& apt-get clean autoclean \
+		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*

--- a/docker/px4-dev/Dockerfile_ros2-bouncy
+++ b/docker/px4-dev/Dockerfile_ros2-bouncy
@@ -50,3 +50,18 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 		pytest-repeat \
 		pytest-runner \
 		pytest-rerunfailures
+
+# Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
+RUN apt-get install -y --quiet python3-genmsg \
+	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.11-2_all.deb -P /tmp/ \
+		&& dpkg -i /tmp/python3-genmsg_0.5.11-2_all.deb \
+		&& apt-get -y autoremove \
+		&& apt-get clean autoclean \
+		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+RUN apt-get install -y --quiet python3-gencpp \
+	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-gencpp/python3-gencpp_0.6.0-4_all.deb -P /tmp/ \
+		&& dpkg -i /tmp/python3-gencpp_0.6.0-4_all.deb \
+		&& apt-get -y autoremove \
+		&& apt-get clean autoclean \
+		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*

--- a/docker/px4-dev/Dockerfile_ros2-crystal
+++ b/docker/px4-dev/Dockerfile_ros2-crystal
@@ -54,16 +54,6 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 		pytest-runner \
 		pytest-rerunfailures
 
-# Build Fast-RTPS release 1.7.0 from source and replace fastrtpsgen
-RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git /tmp/Fast-RTPS \
-	&& cd /tmp/Fast-RTPS \
-	&& mkdir build \
-	&& cd build \
-	&& cmake -DTHIRDPARTY=ON -DBUILD_JAVA=ON .. && make \
-	&& make install \
-	&& ldconfig \
-	&& rm -rf /tmp/*
-
 # Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
 RUN apt-get install -y --quiet python3-genmsg \
 	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.11-2_all.deb -P /tmp/ \

--- a/docker/px4-dev/Dockerfile_ros2-crystal
+++ b/docker/px4-dev/Dockerfile_ros2-crystal
@@ -63,3 +63,18 @@ RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git /tmp/Fast-RT
 	&& make install \
 	&& ldconfig \
 	&& rm -rf /tmp/*
+
+# Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
+RUN apt-get install -y --quiet python3-genmsg \
+	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.11-2_all.deb -P /tmp/ \
+		&& dpkg -i /tmp/python3-genmsg_0.5.11-2_all.deb \
+		&& apt-get -y autoremove \
+		&& apt-get clean autoclean \
+		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+RUN apt-get install -y --quiet python3-gencpp \
+	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-gencpp/python3-gencpp_0.6.0-4_all.deb -P /tmp/ \
+		&& dpkg -i /tmp/python3-gencpp_0.6.0-4_all.deb \
+		&& apt-get -y autoremove \
+		&& apt-get clean autoclean \
+		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*


### PR DESCRIPTION
`px4_ros_com` requires [`genmsg`](http://wiki.ros.org/genmsg) and [`gencpp`](http://wiki.ros.org/gencpp) to generate the required micro-RTPS agent headers and source code. These are both, by default, included in the ROS1 distributions, but not in ROS2.

As `px4_ros_com` is a ROS2 package and we require the aforementioned packages, these need to be installed first in the Python3 path (which is the one used by the ROS2 environment). This allows using `px4_ros_com` standalone without the need of sourcing ROS1 environments (reported in https://github.com/PX4/px4_ros_com/issues/24).

Since `python3-genmsg` and `python3-gencpp` are only available in Ubuntu 18.10 and above, one needs to download from the source mirrors and install the deb package manually instead of using `apt`.