### PR TITLE
Fix matplotlib dependency

### DIFF
--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -41,7 +41,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 	# pip
 	&& pip install px4tools pymavlink \
 	&& pip3 install setuptools wheel \
-	&& pip3 install pyulog matplotlib<=3.0.3 \
+	&& pip3 install pyulog matplotlib==3.0.* \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update

--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -39,9 +39,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	# pip
-	&& pip install --upgrade numpy px4tools pymavlink \
-	&& pip3 install --upgrade setuptools wheel \
-	&& pip3 install --upgrade pyulog matplotlib<=3.0.3 \
+	&& pip install numpy px4tools pymavlink \
+	&& pip3 install setuptools wheel \
+	&& pip3 install pyulog matplotlib<=3.0.3 \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update

--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -39,7 +39,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	# pip
-	&& pip install numpy px4tools pymavlink \
+	&& pip install px4tools pymavlink \
 	&& pip3 install setuptools wheel \
 	&& pip3 install pyulog matplotlib<=3.0.3 \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*

--- a/docker/px4-dev/Dockerfile_ros-kinetic
+++ b/docker/px4-dev/Dockerfile_ros-kinetic
@@ -41,7 +41,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 	# pip
 	&& pip install --upgrade numpy px4tools pymavlink \
 	&& pip3 install --upgrade setuptools wheel \
-	&& pip3 install --upgrade pyulog matplotlib \
+	&& pip3 install --upgrade pyulog matplotlib<=3.0.3 \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update

--- a/docker/px4-dev/Dockerfile_ros-melodic
+++ b/docker/px4-dev/Dockerfile_ros-melodic
@@ -35,7 +35,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	# pip
-	&& pip install numpy px4tools pymavlink \
+	&& pip install px4tools pymavlink \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update

--- a/docker/px4-dev/Dockerfile_ros-melodic
+++ b/docker/px4-dev/Dockerfile_ros-melodic
@@ -35,7 +35,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	# pip
-	&& pip install --upgrade matplotlib numpy px4tools pymavlink \
+	&& pip install --upgrade numpy px4tools pymavlink \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update

--- a/docker/px4-dev/Dockerfile_ros-melodic
+++ b/docker/px4-dev/Dockerfile_ros-melodic
@@ -35,7 +35,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 421C365BD9F
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	# pip
-	&& pip install --upgrade numpy px4tools pymavlink \
+	&& pip install numpy px4tools pymavlink \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update


### PR DESCRIPTION
We added matplotlib here: https://github.com/PX4/containers/pull/86

It is used by px4tools. px4tools manages it's own dependencies here: https://github.com/dronecrew/px4tools/blob/master/setup.py

Version 2.2.x is LTS for python2 and 2.2.4 (current newest) is what is installed from px4tools. Then later in the build, it is upgraded to 3.1, which is not compatible. 

See the blurb on the right at https://matplotlib.org/
```
Matplotlib 3.0 is Python 3 only.

For Python 2 support, Matplotlib 2.2.x will be continued as a LTS release and updated with bugfixes until January 1, 2020.
```
Also,
```
Beginning with Matplotlib 3.1, Python 3.6 or above is required.
```

In the build:
```
Collecting matplotlib>=2.2.2 (from px4tools)
Downloading https://files.pythonhosted.org/packages/32/6b/0368cfa5e1d1ae169ab7dc78addda3fd5e6262e48d7373a9114bac7caff7/matplotlib-2.2.4-cp27-cp27mu-manylinux1_x86_64.whl (12.8MB)
```

So, don't upgrade it. This should fix #185.