### PR TITLE
Update ROS 2 containers

### DIFF
--- a/docker/px4-dev/Dockerfile_ros2-ardent
+++ b/docker/px4-dev/Dockerfile_ros2-ardent
@@ -14,7 +14,7 @@ ENV ROS2_DISTRO ardent
 ENV DEBIAN_FRONTEND noninteractive
 
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \
@@ -25,6 +25,8 @@ RUN apt-get install -y --quiet \
 		ros-$ROS2_DISTRO-desktop \
 		ros-$ROS2_DISTRO-ros1-bridge \
 		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
+		dirmngr \
+		gnupg2 \
 		python3-dev \
 		python3-colcon-common-extensions \
 	&& apt-get -y autoremove \
@@ -38,17 +40,14 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 		argcomplete \
 		flake8 \
 		flake8-blind-except \
-	 	flake8-builtins \
+		flake8-builtins \
 		flake8-class-newline \
 		flake8-comprehensions \
 		flake8-deprecated \
 		flake8-docstrings \
 		flake8-import-order \
 		flake8-quotes \
-		pytest \
-		pytest-cov \
 		pytest-repeat \
-		pytest-runner \
 		pytest-rerunfailures
 
 # Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)

--- a/docker/px4-dev/Dockerfile_ros2-ardent
+++ b/docker/px4-dev/Dockerfile_ros2-ardent
@@ -1,6 +1,6 @@
 #
 # PX4 ROS2 development environment
-# Based from containers under https://github.com/osrf/docker_images/blob/master/ros2/bouncy/ubuntu/bionic/
+# Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source
 #
 
 FROM px4io/px4-dev-ros-kinetic:2019-06-02

--- a/docker/px4-dev/Dockerfile_ros2-ardent
+++ b/docker/px4-dev/Dockerfile_ros2-ardent
@@ -14,7 +14,7 @@ ENV ROS2_DISTRO ardent
 ENV DEBIAN_FRONTEND noninteractive
 
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN curl http://repo.ros2.org/repos.key | apt-key add -
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \

--- a/docker/px4-dev/Dockerfile_ros2-bouncy
+++ b/docker/px4-dev/Dockerfile_ros2-bouncy
@@ -14,7 +14,7 @@ ENV ROS2_DISTRO bouncy
 ENV DEBIAN_FRONTEND noninteractive
 
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \
@@ -25,6 +25,8 @@ RUN apt-get install -y --quiet \
 		ros-$ROS2_DISTRO-desktop \
 		ros-$ROS2_DISTRO-ros1-bridge \
 		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
+		dirmngr \
+		gnupg2 \
 		python3-dev \
 		python3-colcon-common-extensions \
 	&& apt-get -y autoremove \
@@ -38,17 +40,14 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 		argcomplete \
 		flake8 \
 		flake8-blind-except \
-	 	flake8-builtins \
+		flake8-builtins \
 		flake8-class-newline \
 		flake8-comprehensions \
 		flake8-deprecated \
 		flake8-docstrings \
 		flake8-import-order \
 		flake8-quotes \
-		pytest \
-		pytest-cov \
 		pytest-repeat \
-		pytest-runner \
 		pytest-rerunfailures
 
 # Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)

--- a/docker/px4-dev/Dockerfile_ros2-bouncy
+++ b/docker/px4-dev/Dockerfile_ros2-bouncy
@@ -1,6 +1,6 @@
 #
 # PX4 ROS2 development environment
-# Based from containers under https://github.com/osrf/docker_images/blob/master/ros2/bouncy/ubuntu/bionic/
+# Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source
 #
 
 FROM px4io/px4-dev-ros-melodic:2019-06-02

--- a/docker/px4-dev/Dockerfile_ros2-bouncy
+++ b/docker/px4-dev/Dockerfile_ros2-bouncy
@@ -14,7 +14,7 @@ ENV ROS2_DISTRO bouncy
 ENV DEBIAN_FRONTEND noninteractive
 
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN curl http://repo.ros2.org/repos.key | apt-key add -
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \

--- a/docker/px4-dev/Dockerfile_ros2-crystal
+++ b/docker/px4-dev/Dockerfile_ros2-crystal
@@ -14,7 +14,7 @@ ENV ROS2_DISTRO crystal
 ENV DEBIAN_FRONTEND noninteractive
 
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+RUN curl http://repo.ros2.org/repos.key | apt-key add -
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \

--- a/docker/px4-dev/Dockerfile_ros2-crystal
+++ b/docker/px4-dev/Dockerfile_ros2-crystal
@@ -14,7 +14,7 @@ ENV ROS2_DISTRO crystal
 ENV DEBIAN_FRONTEND noninteractive
 
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \
@@ -27,7 +27,6 @@ RUN apt-get install -y --quiet \
 		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
 		dirmngr \
 		gnupg2 \
-		gradle \
 		python3-dev \
 		python3-colcon-common-extensions \
 	&& apt-get -y autoremove \
@@ -41,17 +40,14 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 		argcomplete \
 		flake8 \
 		flake8-blind-except \
-	 	flake8-builtins \
+		flake8-builtins \
 		flake8-class-newline \
 		flake8-comprehensions \
 		flake8-deprecated \
 		flake8-docstrings \
 		flake8-import-order \
 		flake8-quotes \
-		pytest \
-		pytest-cov \
 		pytest-repeat \
-		pytest-runner \
 		pytest-rerunfailures
 
 # Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)

--- a/docker/px4-dev/Dockerfile_ros2-crystal
+++ b/docker/px4-dev/Dockerfile_ros2-crystal
@@ -1,6 +1,6 @@
 #
 # PX4 ROS2 development environment
-# Based from containers under https://github.com/osrf/docker_images/tree/master/ros2/crystal/ubuntu/bionic/
+# Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source
 #
 
 FROM px4io/px4-dev-ros-melodic:2019-06-02


### PR DESCRIPTION
ROS2 apt-keys seemed to change, causing failures on the container build: https://cloud.docker.com/u/px4io/repository/registry-1.docker.io/px4io/px4-dev-ros2-crystal/builds/0d60a3f4-808e-48d7-9d5e-6f4fd13ad978. This PR updates the apt-keys and also updates the dependencies installation.