### PR TITLE
px4-dev-ros2-bouncy: change base container to ros-kinetic

### DIFF
--- a/docker/px4-dev/Dockerfile_ros2-bouncy
+++ b/docker/px4-dev/Dockerfile_ros2-bouncy
@@ -3,13 +3,13 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-melodic:2019-06-27
+FROM px4io/px4-dev-ros-kinetic:2019-06-27
 LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
 
 # setup environment
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
-ENV ROS1_DISTRO melodic
+ENV ROS1_DISTRO kinetic
 ENV ROS2_DISTRO bouncy
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
ROS2 Bouncy officially just supports Fast-RTPS until version 1.6.0 (https://github.com/ros2-gbp/fastrtps-release#fastrtps-bouncy---160-5). So I am basing of the Xenial/Kinetic container, where the Fast-RTPS version is 1.6.0.