### PR TITLE
Fast-RTPS: sync version for each ROS2 release

### DIFF
--- a/docker/px4-dev/Dockerfile_base-bionic
+++ b/docker/px4-dev/Dockerfile_base-bionic
@@ -79,11 +79,11 @@ RUN wget -q "https://services.gradle.org/distributions/gradle-5.4.1-bin.zip" -O 
 ENV PATH "/opt/gradle/gradle-5.4.1/bin:$PATH"
 
 # Fast-RTPS
-RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b release/1.7.2 /tmp/Fast-RTPS-1.7.2 \
-	&& cd /tmp/Fast-RTPS-1.7.2 \
-	&& mkdir build && cd build \
-	&& cmake -DTHIRDPARTY=ON -DBUILD_JAVA=ON .. \
-	&& make && make install \
+RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-7-2/eprosima_fastrtps-1-7-2-linux-tar-gz?format=raw" -O /tmp/eprosima_fastrtps.tar.gz \
+	&& cd /tmp && tar zxf eprosima_fastrtps.tar.gz \
+	&& cd eProsima_FastRTPS-1.7.2-Linux \
+	&& ./configure CXXFLAGS="-g -D__DEBUG" --libdir=/usr/lib \
+	&& make install \
 	&& rm -rf /tmp/*
 
 # create user with id 1001 (jenkins docker workflow default)

--- a/docker/px4-dev/Dockerfile_base-xenial
+++ b/docker/px4-dev/Dockerfile_base-xenial
@@ -72,11 +72,10 @@ RUN wget -q https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.0
 # Fast-RTPS
 RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-6-0/eprosima_fastrtps-1-6-0-linux-tar-gz?format=raw" -O /tmp/eprosima_fastrtps.tar.gz \
 	&& cd /tmp && tar zxf eprosima_fastrtps.tar.gz \
-	&& mkdir -p /usr/local/share/fastrtps \
-	&& cp eProsima_FastRTPS-1.6.0-Linux/share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/fastrtpsgen.jar \
-	&& cp eProsima_FastRTPS-1.6.0-Linux/bin/fastrtpsgen /usr/local/bin/fastrtpsgen \
+	&& cd eProsima_FastRTPS-1.6.0-Linux \
+	&& ./configure CXXFLAGS="-g -D__DEBUG" --libdir=/usr/lib \
+	&& make install \
 	&& rm -rf /tmp/*
-
 
 # create user with id 1001 (jenkins docker workflow default)
 RUN useradd --shell /bin/bash -u 1001 -c "" -m user && usermod -a -G dialout user

--- a/docker/px4-dev/Dockerfile_ros2-bouncy
+++ b/docker/px4-dev/Dockerfile_ros2-bouncy
@@ -65,3 +65,11 @@ RUN apt-get install -y --quiet python3-gencpp \
 		&& apt-get -y autoremove \
 		&& apt-get clean autoclean \
 		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# downgrade Fast-RTPS to 1.6.0 (from the base container), as ROS2 Bouncy only supports Fast-RTPS 1.6.0
+RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-6-0/eprosima_fastrtps-1-6-0-linux-tar-gz?format=raw" -O /tmp/eprosima_fastrtps.tar.gz \
+	&& cd /tmp && tar zxf eprosima_fastrtps.tar.gz \
+	&& cd eProsima_FastRTPS-1.6.0-Linux \
+	&& ./configure CXXFLAGS="-g -D__DEBUG" --libdir=/usr/lib \
+	&& make install \
+	&& rm -rf /tmp/*


### PR DESCRIPTION
This PR matches the releases of Fast-RTPS with the respective used version in ROS2. By default, we are keeping Fast-RTPS 1.7.2 as the stable Fast-RTPS version, as it is supported in both ROS 2 Crystal (the currently supported released for `px4_ros_com`) and Dashing (LTS, but pending support in `px4_ros_com`).