### PR TITLE
docker: add ROS2 Eloquent container | update ROS2 containers dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -445,6 +445,32 @@ pipeline {
             }
           }
         }
+
+        stage('px4-dev-ros2-eloquent') {
+          agent {
+            dockerfile {
+              filename 'Dockerfile_ros2-eloquent'
+              dir 'docker'
+              args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
+            }
+          }
+          steps {
+            sh 'git clone --recursive https://github.com/PX4/Firmware.git colcon_ws/src/Firmware'
+            sh '''#!/bin/bash -l
+              cd colcon_ws;
+              source /opt/ros/eloquent/setup.bash;
+              colcon build --event-handlers console_direct+ --symlink-install;
+            '''
+          }
+          post {
+            always {
+              sh 'rm -rf colcon_ws'
+            }
+            failure {
+              archiveArtifacts(allowEmptyArchive: false, artifacts: '.ros/**/*.xml, .ros/**/*.log')
+            }
+          }
+        }
       } // parallel
     } // Build ROS2 (after ROS1)
 

--- a/docker/Dockerfile_base-archlinux
+++ b/docker/Dockerfile_base-archlinux
@@ -62,7 +62,7 @@ RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b 1.8.x /tm
 	&& rm -rf /tmp/*
 
 # Fast-RTPS-Gen (required since Fast-RTPS-Gen got split from Fast-RTPS repo since 1.8.x)
-RUN git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.1 /tmp/Fast-RTPS-Gen \
+RUN git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.2 /tmp/Fast-RTPS-Gen \
 	&& cd /tmp/Fast-RTPS-Gen \
 	&& gradle assemble \
 	&& cp share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/ \

--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -88,7 +88,7 @@ RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b 1.8.x /tm
 	&& rm -rf /tmp/*
 
 # Fast-RTPS-Gen (required since Fast-RTPS-Gen got split from Fast-RTPS repo since 1.8.x)
-RUN git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.1 /tmp/Fast-RTPS-Gen \
+RUN git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.2 /tmp/Fast-RTPS-Gen \
 	&& cd /tmp/Fast-RTPS-Gen \
 	&& gradle assemble \
 	&& cp share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/ \

--- a/docker/Dockerfile_ros-melodic
+++ b/docker/Dockerfile_ros-melodic
@@ -19,6 +19,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 		libopencv-dev \
 		python-catkin-tools \
 		python-tk \
+		python3-pip \
 		ros-$ROS_DISTRO-gazebo-ros-pkgs \
 		ros-$ROS_DISTRO-mavlink \
 		ros-$ROS_DISTRO-mavros \
@@ -36,6 +37,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 	&& apt-get clean autoclean \
 	# pip
 	&& pip install px4tools pymavlink \
+	&& pip3 install setuptools wheel \
+	&& pip3 install pyulog matplotlib==3.0.* \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update

--- a/docker/Dockerfile_ros2-ardent
+++ b/docker/Dockerfile_ros2-ardent
@@ -20,13 +20,16 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \
 	&& apt-get update
 
-# install ros2 desktop and ros1-bridge
+# install ros2 desktop
 RUN apt-get install -y --quiet \
-		ros-$ROS2_DISTRO-desktop \
-		ros-$ROS2_DISTRO-ros1-bridge \
-		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
-		python3-dev \
+		python3-catkin-pkg \
 		python3-colcon-common-extensions \
+		python3-dev \
+		python3-rosdep \
+		python3-rospkg \
+		python3-vcstool \
+		ros-$ROS2_DISTRO-desktop \
+		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
@@ -34,24 +37,30 @@ RUN apt-get install -y --quiet \
 # install python packages needed for testing
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 	&& python3 -m pip install --upgrade pip \
-		setuptools \
 		argcomplete \
+		colcon-common-extensions \
+		colcon-mixin \
 		flake8 \
 		flake8-blind-except \
-	 	flake8-builtins \
+		flake8-builtins \
 		flake8-class-newline \
 		flake8-comprehensions \
 		flake8-deprecated \
 		flake8-docstrings \
 		flake8-import-order \
 		flake8-quotes \
-		pytest \
-		pytest-cov \
 		pytest-repeat \
-		pytest-runner \
 		pytest-rerunfailures
 
-# Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
+RUN rosdep init && rosdep update
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \
+	&& colcon mixin update \
+	&& colcon metadata add default https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml \
+	&& colcon metadata update
+
+# install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
 RUN apt-get install -y --quiet python3-genmsg \
 	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.11-2_all.deb -P /tmp/ \
 		&& dpkg -i /tmp/python3-genmsg_0.5.11-2_all.deb \

--- a/docker/Dockerfile_ros2-ardent
+++ b/docker/Dockerfile_ros2-ardent
@@ -22,11 +22,8 @@ RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc
 
 # install ros2 desktop
 RUN apt-get install -y --quiet \
-		python3-catkin-pkg \
 		python3-colcon-common-extensions \
 		python3-dev \
-		python3-rosdep \
-		python3-rospkg \
 		python3-vcstool \
 		ros-$ROS2_DISTRO-desktop \
 		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
@@ -52,7 +49,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 		pytest-repeat \
 		pytest-rerunfailures
 
-RUN rosdep init && rosdep update
+RUN rosdep update
 
 # setup colcon mixin and metadata
 RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \

--- a/docker/Dockerfile_ros2-bouncy
+++ b/docker/Dockerfile_ros2-bouncy
@@ -20,13 +20,16 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \
 	&& apt-get update
 
-# install ros2 desktop and ros1-bridge
+# install ros2 desktop
 RUN apt-get install -y --quiet \
-		ros-$ROS2_DISTRO-desktop \
-		ros-$ROS2_DISTRO-ros1-bridge \
-		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
-		python3-dev \
+		python3-catkin-pkg \
 		python3-colcon-common-extensions \
+		python3-dev \
+		python3-rosdep \
+		python3-rospkg \
+		python3-vcstool \
+		ros-$ROS2_DISTRO-desktop \
+		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
@@ -34,24 +37,30 @@ RUN apt-get install -y --quiet \
 # install python packages needed for testing
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 	&& python3 -m pip install --upgrade pip \
-		setuptools \
 		argcomplete \
+		colcon-common-extensions \
+		colcon-mixin \
 		flake8 \
 		flake8-blind-except \
-	 	flake8-builtins \
+		flake8-builtins \
 		flake8-class-newline \
 		flake8-comprehensions \
 		flake8-deprecated \
 		flake8-docstrings \
 		flake8-import-order \
 		flake8-quotes \
-		pytest \
-		pytest-cov \
 		pytest-repeat \
-		pytest-runner \
 		pytest-rerunfailures
 
-# Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
+RUN rosdep init && rosdep update
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \
+	&& colcon mixin update \
+	&& colcon metadata add default https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml \
+	&& colcon metadata update
+
+# install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
 RUN apt-get install -y --quiet python3-genmsg \
 	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.11-2_all.deb -P /tmp/ \
 		&& dpkg -i /tmp/python3-genmsg_0.5.11-2_all.deb \

--- a/docker/Dockerfile_ros2-bouncy
+++ b/docker/Dockerfile_ros2-bouncy
@@ -22,11 +22,8 @@ RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc
 
 # install ros2 desktop
 RUN apt-get install -y --quiet \
-		python3-catkin-pkg \
 		python3-colcon-common-extensions \
 		python3-dev \
-		python3-rosdep \
-		python3-rospkg \
 		python3-vcstool \
 		ros-$ROS2_DISTRO-desktop \
 		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
@@ -52,7 +49,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 		pytest-repeat \
 		pytest-rerunfailures
 
-RUN rosdep init && rosdep update
+RUN rosdep update
 
 # setup colcon mixin and metadata
 RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \

--- a/docker/Dockerfile_ros2-crystal
+++ b/docker/Dockerfile_ros2-crystal
@@ -22,11 +22,8 @@ RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc
 
 # install ros2 desktop
 RUN apt-get install -y --quiet \
-		python3-catkin-pkg \
 		python3-colcon-common-extensions \
 		python3-dev \
-		python3-rosdep \
-		python3-rospkg \
 		python3-vcstool \
 		ros-$ROS2_DISTRO-desktop \
 		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
@@ -52,7 +49,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 		pytest-repeat \
 		pytest-rerunfailures
 
-RUN rosdep init && rosdep update
+RUN rosdep update
 
 # setup colcon mixin and metadata
 RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \

--- a/docker/Dockerfile_ros2-crystal
+++ b/docker/Dockerfile_ros2-crystal
@@ -20,16 +20,16 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \
 	&& apt-get update
 
-# install ros2 desktop and ros1-bridge
+# install ros2 desktop
 RUN apt-get install -y --quiet \
-		ros-$ROS2_DISTRO-desktop \
-		ros-$ROS2_DISTRO-ros1-bridge \
-		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
-		dirmngr \
-		gnupg2 \
-		gradle \
-		python3-dev \
+		python3-catkin-pkg \
 		python3-colcon-common-extensions \
+		python3-dev \
+		python3-rosdep \
+		python3-rospkg \
+		python3-vcstool \
+		ros-$ROS2_DISTRO-desktop \
+		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
@@ -37,24 +37,30 @@ RUN apt-get install -y --quiet \
 # install python packages needed for testing
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 	&& python3 -m pip install --upgrade pip \
-		setuptools \
 		argcomplete \
+		colcon-common-extensions \
+		colcon-mixin \
 		flake8 \
 		flake8-blind-except \
-	 	flake8-builtins \
+		flake8-builtins \
 		flake8-class-newline \
 		flake8-comprehensions \
 		flake8-deprecated \
 		flake8-docstrings \
 		flake8-import-order \
 		flake8-quotes \
-		pytest \
-		pytest-cov \
 		pytest-repeat \
-		pytest-runner \
 		pytest-rerunfailures
 
-# Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
+RUN rosdep init && rosdep update
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \
+	&& colcon mixin update \
+	&& colcon metadata add default https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml \
+	&& colcon metadata update
+
+# install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
 RUN apt-get install -y --quiet python3-genmsg \
 	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.11-2_all.deb -P /tmp/ \
 		&& dpkg -i /tmp/python3-genmsg_0.5.11-2_all.deb \

--- a/docker/Dockerfile_ros2-dashing
+++ b/docker/Dockerfile_ros2-dashing
@@ -22,11 +22,8 @@ RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc
 
 # install ros2 desktop
 RUN apt-get install -y --quiet \
-		python3-catkin-pkg \
 		python3-colcon-common-extensions \
 		python3-dev \
-		python3-rosdep \
-		python3-rospkg \
 		python3-vcstool \
 		ros-$ROS2_DISTRO-desktop \
 		ros-$ROS2_DISTRO-launch-testing-ament-cmake \
@@ -53,7 +50,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 		pytest-repeat \
 		pytest-rerunfailures
 
-RUN rosdep init && rosdep update
+RUN rosdep update
 
 # setup colcon mixin and metadata
 RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \

--- a/docker/Dockerfile_ros2-dashing
+++ b/docker/Dockerfile_ros2-dashing
@@ -20,16 +20,17 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \
 	&& apt-get update
 
-# install ros2 desktop and ros1-bridge
+# install ros2 desktop
 RUN apt-get install -y --quiet \
-		ros-$ROS2_DISTRO-desktop \
-		ros-$ROS2_DISTRO-ros1-bridge \
-		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
-		dirmngr \
-		gnupg2 \
-		gradle \
-		python3-dev \
+		python3-catkin-pkg \
 		python3-colcon-common-extensions \
+		python3-dev \
+		python3-rosdep \
+		python3-rospkg \
+		python3-vcstool \
+		ros-$ROS2_DISTRO-desktop \
+		ros-$ROS2_DISTRO-launch-testing-ament-cmake \
+		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
@@ -37,22 +38,28 @@ RUN apt-get install -y --quiet \
 # install python packages needed for testing
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 	&& python3 -m pip install --upgrade pip \
-		setuptools \
 		argcomplete \
+		colcon-common-extensions \
+		colcon-mixin \
 		flake8 \
 		flake8-blind-except \
-	 	flake8-builtins \
+		flake8-builtins \
 		flake8-class-newline \
 		flake8-comprehensions \
 		flake8-deprecated \
 		flake8-docstrings \
 		flake8-import-order \
 		flake8-quotes \
-		pytest \
-		pytest-cov \
 		pytest-repeat \
-		pytest-runner \
 		pytest-rerunfailures
+
+RUN rosdep init && rosdep update
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \
+	&& colcon mixin update \
+	&& colcon metadata add default https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml \
+	&& colcon metadata update
 
 # Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
 RUN apt-get install -y --quiet python3-genmsg \

--- a/docker/Dockerfile_ros2-eloquent
+++ b/docker/Dockerfile_ros2-eloquent
@@ -22,11 +22,8 @@ RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc
 
 # install ros2 desktop
 RUN apt-get install -y --quiet \
-		python3-catkin-pkg \
 		python3-colcon-common-extensions \
 		python3-dev \
-		python3-rosdep \
-		python3-rospkg \
 		python3-vcstool \
 		ros-$ROS2_DISTRO-desktop \
 		ros-$ROS2_DISTRO-launch-testing-ament-cmake \
@@ -53,7 +50,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 		pytest-repeat \
 		pytest-rerunfailures
 
-RUN rosdep init && rosdep update
+RUN rosdep update
 
 # setup colcon mixin and metadata
 RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \

--- a/docker/Dockerfile_ros2-eloquent
+++ b/docker/Dockerfile_ros2-eloquent
@@ -1,0 +1,78 @@
+#
+# PX4 ROS2 development environment
+# Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
+#
+
+FROM px4io/px4-dev-ros-melodic:2019-10-04
+LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV ROS1_DISTRO melodic
+ENV ROS2_DISTRO eloquent
+ENV DEBIAN_FRONTEND noninteractive
+
+# setup ros2 keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \
+	&& apt-get update
+
+# install ros2 desktop and ros1-bridge
+RUN apt-get install -y --quiet \
+		ros-$ROS2_DISTRO-desktop \
+		ros-$ROS2_DISTRO-ros1-bridge \
+		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
+		dirmngr \
+		gnupg2 \
+		gradle \
+		python3-dev \
+		python3-colcon-common-extensions \
+	&& apt-get -y autoremove \
+	&& apt-get clean autoclean \
+	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# install python packages needed for testing
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
+	&& python3 -m pip install --upgrade pip \
+		setuptools \
+		argcomplete \
+		flake8 \
+		flake8-blind-except \
+	 	flake8-builtins \
+		flake8-class-newline \
+		flake8-comprehensions \
+		flake8-deprecated \
+		flake8-docstrings \
+		flake8-import-order \
+		flake8-quotes \
+		pytest \
+		pytest-cov \
+		pytest-repeat \
+		pytest-runner \
+		pytest-rerunfailures
+
+# Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
+RUN apt-get install -y --quiet python3-genmsg \
+	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.11-2_all.deb -P /tmp/ \
+		&& dpkg -i /tmp/python3-genmsg_0.5.11-2_all.deb \
+		&& apt-get -y autoremove \
+		&& apt-get clean autoclean \
+		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+RUN apt-get install -y --quiet python3-gencpp \
+	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-gencpp/python3-gencpp_0.6.0-4_all.deb -P /tmp/ \
+		&& dpkg -i /tmp/python3-gencpp_0.6.0-4_all.deb \
+		&& apt-get -y autoremove \
+		&& apt-get clean autoclean \
+		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# Install Fast-RTPS 1.9.1
+RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b 1.9.x /tmp/FastRTPS-1.9.1 \
+	&& cd /tmp/FastRTPS-1.9.1 \
+	&& mkdir build && cd build \
+	&& cmake -DTHIRDPARTY=ON -DSECURITY=ON .. \
+	&& cmake --build . --target install \
+	&& rm -rf /tmp/*

--- a/docker/Dockerfile_ros2-eloquent
+++ b/docker/Dockerfile_ros2-eloquent
@@ -73,9 +73,17 @@ RUN apt-get install -y --quiet python3-gencpp \
 		&& apt-get clean autoclean \
 		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-# Install Fast-RTPS 1.9.1
-RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b 1.9.x /tmp/FastRTPS-1.9.1 \
-	&& cd /tmp/FastRTPS-1.9.1 \
+# Intall foonathan_memory from source as it is required to Fast-RTPS >= 1.9
+RUN git clone https://github.com/eProsima/foonathan_memory_vendor.git /tmp/foonathan_memory \
+	&& cd /tmp/foonathan_memory \
+	&& mkdir build && cd build \
+	&& cmake .. \
+	&& cmake --build . --target install \
+	&& rm -rf /tmp/*
+
+# Install Fast-RTPS 1.9.2
+RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b 1.9.x /tmp/FastRTPS-1.9.2 \
+	&& cd /tmp/FastRTPS-1.9.2 \
 	&& mkdir build && cd build \
 	&& cmake -DTHIRDPARTY=ON -DSECURITY=ON .. \
 	&& cmake --build . --target install \

--- a/docker/Dockerfile_ros2-eloquent
+++ b/docker/Dockerfile_ros2-eloquent
@@ -20,16 +20,17 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list \
 	&& apt-get update
 
-# install ros2 desktop and ros1-bridge
+# install ros2 desktop
 RUN apt-get install -y --quiet \
-		ros-$ROS2_DISTRO-desktop \
-		ros-$ROS2_DISTRO-ros1-bridge \
-		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
-		dirmngr \
-		gnupg2 \
-		gradle \
-		python3-dev \
+		python3-catkin-pkg \
 		python3-colcon-common-extensions \
+		python3-dev \
+		python3-rosdep \
+		python3-rospkg \
+		python3-vcstool \
+		ros-$ROS2_DISTRO-desktop \
+		ros-$ROS2_DISTRO-launch-testing-ament-cmake \
+		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
@@ -37,22 +38,28 @@ RUN apt-get install -y --quiet \
 # install python packages needed for testing
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
 	&& python3 -m pip install --upgrade pip \
-		setuptools \
 		argcomplete \
+		colcon-common-extensions \
+		colcon-mixin \
 		flake8 \
 		flake8-blind-except \
-	 	flake8-builtins \
+		flake8-builtins \
 		flake8-class-newline \
 		flake8-comprehensions \
 		flake8-deprecated \
 		flake8-docstrings \
 		flake8-import-order \
 		flake8-quotes \
-		pytest \
-		pytest-cov \
 		pytest-repeat \
-		pytest-runner \
 		pytest-rerunfailures
+
+RUN rosdep init && rosdep update
+
+# setup colcon mixin and metadata
+RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml \
+	&& colcon mixin update \
+	&& colcon metadata add default https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml \
+	&& colcon metadata update
 
 # Install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
 RUN apt-get install -y --quiet python3-genmsg \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,15 +3,15 @@
 		px4-dev-base-xenial, px4-dev-clang, px4-dev-ecl, px4-dev-nuttx, \
 		px4-dev-nuttx-clang, px4-dev-raspi, px4-dev-ros-kinetic, \
 		px4-dev-ros-melodic, px4-dev-ros2-ardent, px4-dev-ros2-bouncy, \
-		px4-dev-ros2-crystal, px4-dev-ros2-dashing, px4-dev-simulation-xenial, \
-		px4-dev-simulation-bionic
+		px4-dev-ros2-crystal, px4-dev-ros2-dashing, px4-dev-ros2-eloquent, \
+		px4-dev-simulation-xenial, px4-dev-simulation-bionic
 
 all: px4-dev-armhf, px4-dev-base-archlinux, px4-dev-base-bionic, \
 		px4-dev-base-xenial, px4-dev-clang, px4-dev-ecl, px4-dev-nuttx, \
 		px4-dev-nuttx-clang, px4-dev-raspi, px4-dev-ros-kinetic, \
 		px4-dev-ros-melodic, px4-dev-ros2-ardent, px4-dev-ros2-bouncy, \
-		px4-dev-ros2-crystal, px4-dev-ros2-dashing, px4-dev-simulation-xenial, \
-		px4-dev-simulation-bionic
+		px4-dev-ros2-crystal, px4-dev-ros2-dashing, px4-dev-ros2-eloquent, \
+		px4-dev-simulation-xenial, px4-dev-simulation-bionic
 
 px4-dev-armhf: px4-dev-base-bionic
 	docker build -t px4io/px4-dev-armhf . -f Dockerfile_armhf
@@ -60,6 +60,9 @@ px4-dev-ros2-bouncy: px4-dev-ros-melodic
 
 px4-dev-ros2-dashing: px4-dev-ros-melodic
 	docker build -t px4io/px4-dev-ros2-dashing . -f Dockerfile_ros2-dashing
+
+px4-dev-ros2-eloquent: px4-dev-ros-melodic
+	docker build -t px4io/px4-dev-ros2-eloquent . -f Dockerfile_ros2-eloquent
 
 px4-dev-simulation-xenial: px4-dev-base-xenial
 	docker build -t px4io/px4-dev-simulation-xenial . -f Dockerfile_simulation-xenial

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,6 +19,7 @@ License: according to LICENSE.md in the root directory of the PX4 Firmware repos
        - px4-dev-ros2-bouncy
        - px4-dev-ros2-crystal
        - px4-dev-ros2-dashing
+       - px4-dev-ros2-eloquent
  - px4-dev-base-xenial
    - px4-dev-simulation-xenial
      - px4-dev-ros-kinetic


### PR DESCRIPTION
Alpha release already happen. Roadmap under https://index.ros.org//doc/ros2/Releases/Release-Eloquent-Elusor/#id6.