### PR TITLE
Add avoidance dependencies for testing

### DIFF
--- a/docker/Dockerfile_ros-kinetic
+++ b/docker/Dockerfile_ros-kinetic
@@ -18,13 +18,17 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 		libeigen3-dev \
 		libgeographic-dev \
 		libopencv-dev \
+		libyaml-cpp-dev \
 		protobuf-compiler \
 		python-catkin-tools \
 		python-tk \
 		ros-$ROS_DISTRO-gazebo-ros-pkgs \
+		ros-$ROS_DISTRO-mav-msgs \
 		ros-$ROS_DISTRO-mavlink \
 		ros-$ROS_DISTRO-mavros \
 		ros-$ROS_DISTRO-mavros-extras \
+		ros-$ROS_DISTRO-octomap \
+		ros-$ROS_DISTRO-octomap-msgs \
 		ros-$ROS_DISTRO-pcl-conversions \
 		ros-$ROS_DISTRO-pcl-msgs \
 		ros-$ROS_DISTRO-pcl-ros \

--- a/docker/Dockerfile_ros-melodic
+++ b/docker/Dockerfile_ros-melodic
@@ -16,12 +16,16 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 		libeigen3-dev \
 		libgeographic-dev \
 		libopencv-dev \
+		libyaml-cpp-dev \
 		python-catkin-tools \
 		python-tk \
 		ros-$ROS_DISTRO-gazebo-ros-pkgs \
+		ros-$ROS_DISTRO-mav-msgs \
 		ros-$ROS_DISTRO-mavlink \
 		ros-$ROS_DISTRO-mavros \
 		ros-$ROS_DISTRO-mavros-extras \
+		ros-$ROS_DISTRO-octomap \
+		ros-$ROS_DISTRO-octomap-msgs \
 		ros-$ROS_DISTRO-pcl-conversions \
 		ros-$ROS_DISTRO-pcl-msgs \
 		ros-$ROS_DISTRO-pcl-ros \


### PR DESCRIPTION
This PR adds dependencies for the [PX4/avoidance](https://github.com/PX4/avoidance) to enable SITL testing on Jenkins.

I am not sure if making the `px4io/px4-dev-ros-melodic` image larger will be a better decision instead of creating a docker image just for the avoidance testing.