### PR TITLE
docker: add MAVSDK library to simulation-bionic

### DIFF
--- a/docker/Dockerfile_simulation-bionic
+++ b/docker/Dockerfile_simulation-bionic
@@ -40,3 +40,7 @@ ENV SVGA_VGPU10 0
 
 # Use UTF8 encoding in java tools (needed to compile jMAVSim)
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+
+# Install MAVSDK library
+RUN wget https://github.com/mavlink/MAVSDK/releases/download/v0.21.3/mavsdk_0.21.3_ubuntu18.04_amd64.deb \
+    && dpkg -i mavsdk_0.21.3_ubuntu18.04_amd64.deb


### PR DESCRIPTION
This is required for testing using MAVSDK in https://github.com/PX4/Firmware/pull/13075.