### PR TITLE
Install catkin_pkg by pip3

### DIFF
--- a/docker/Dockerfile_ros-kinetic
+++ b/docker/Dockerfile_ros-kinetic
@@ -39,6 +39,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 	&& apt-get clean autoclean \
 	# pip2
 	&& pip install px4tools pymavlink \
+	# pip3
+	&& pip3 install catkin_pkg \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update

--- a/docker/Dockerfile_ros-melodic
+++ b/docker/Dockerfile_ros-melodic
@@ -36,6 +36,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 	&& apt-get clean autoclean \
 	# pip2
 	&& pip install px4tools pymavlink \
+	# pip3
+	&& pip3 install catkin_pkg \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update


### PR DESCRIPTION
As per https://github.com/PX4/sitl_gazebo/pull/373, we also need *catkin_pkg* installed in the Python 3 path, in order to build catkin packages.