### PR TITLE
install pyros-genmsg with pip3 (equivalent to python3-genmsg) on base containers

### DIFF
--- a/docker/Dockerfile_base-archlinux
+++ b/docker/Dockerfile_base-archlinux
@@ -25,11 +25,11 @@ RUN pacman -Sy --noconfirm \
 		wget \
 		zip
 
-# Install python dependencies
+# python3 dependencies installed by pip
 RUN python3 -m pip install --upgrade pip \
 	&& pip3 install argparse argcomplete coverage cerberus empy jinja2 \
-		matplotlib==3.0.* numpy pkgconfig pyulog pyyaml requests serial \
-		toml pyulog wheel
+		matplotlib==3.0.* numpy pkgconfig pyros-genmsg pyulog pyyaml \
+		requests serial toml pyulog wheel
 
 # Install genromfs
 RUN wget https://sourceforge.net/projects/romfs/files/genromfs/0.5.2/genromfs-0.5.2.tar.gz \

--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -60,8 +60,8 @@ RUN cd /usr/src/gtest \
 # python3 dependencies installed by pip
 RUN python3 -m pip install --upgrade pip \
 	&& pip3 install argparse argcomplete coverage cerberus empy jinja2 \
-		matplotlib==3.0.* numpy pkgconfig pyulog pyyaml requests serial \
-		toml pyulog wheel
+		matplotlib==3.0.* numpy pkgconfig pyros-genmsg pyulog pyyaml \
+		requests serial toml pyulog wheel
 
 # manual ccache setup
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \

--- a/docker/Dockerfile_base-xenial
+++ b/docker/Dockerfile_base-xenial
@@ -60,8 +60,8 @@ RUN cd /usr/src/gtest \
 # python3 dependencies installed by pip
 RUN python3 -m pip install --upgrade pip \
 	&& pip3 install argparse argcomplete coverage cerberus empy jinja2 \
-		matplotlib==3.0.* numpy pkgconfig pyulog pyyaml requests serial \
-		toml pyulog wheel
+		matplotlib==3.0.* numpy pkgconfig pyros-genmsg pyulog pyyaml \
+		requests serial toml pyulog wheel
 
 # manual ccache setup
 RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \

--- a/docker/Dockerfile_ros2-ardent
+++ b/docker/Dockerfile_ros2-ardent
@@ -55,18 +55,3 @@ RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mix
 	&& colcon mixin update \
 	&& colcon metadata add default https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml \
 	&& colcon metadata update
-
-# install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
-RUN apt-get install -y --quiet python3-genmsg \
-	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.12-1_all.deb -P /tmp/ \
-		&& dpkg -i /tmp/python3-genmsg_0.5.12-1_all.deb \
-		&& apt-get -y autoremove \
-		&& apt-get clean autoclean \
-		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
-RUN apt-get install -y --quiet python3-gencpp \
-	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-gencpp/python3-gencpp_0.6.2-2_all.deb -P /tmp/ \
-		&& dpkg -i /tmp/python3-gencpp_0.6.2-2_all.deb \
-		&& apt-get -y autoremove \
-		&& apt-get clean autoclean \
-		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*

--- a/docker/Dockerfile_ros2-bouncy
+++ b/docker/Dockerfile_ros2-bouncy
@@ -56,21 +56,6 @@ RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mix
 	&& colcon metadata add default https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml \
 	&& colcon metadata update
 
-# install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
-RUN apt-get install -y --quiet python3-genmsg \
-	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.12-1_all.deb -P /tmp/ \
-		&& dpkg -i /tmp/python3-genmsg_0.5.12-1_all.deb \
-		&& apt-get -y autoremove \
-		&& apt-get clean autoclean \
-		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
-RUN apt-get install -y --quiet python3-gencpp \
-	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-gencpp/python3-gencpp_0.6.2-2_all.deb -P /tmp/ \
-		&& dpkg -i /tmp/python3-gencpp_0.6.2-2_all.deb \
-		&& apt-get -y autoremove \
-		&& apt-get clean autoclean \
-		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
 # downgrade Fast-RTPS to 1.6.0 (from the base container), as ROS2 Bouncy only supports Fast-RTPS 1.6.0
 RUN rm -rf /usr/local/include/fastrtps /usr/local/share/fastrtps /usr/local/lib/libfastrtps* /usr/local/bin/fastrtpsgen \
 	&& wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-6-0/eprosima_fastrtps-1-6-0-linux-tar-gz?format=raw" -O /tmp/eprosima_fastrtps.tar.gz \

--- a/docker/Dockerfile_ros2-crystal
+++ b/docker/Dockerfile_ros2-crystal
@@ -56,22 +56,6 @@ RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mix
 	&& colcon metadata add default https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml \
 	&& colcon metadata update
 
-# install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
-RUN apt-get install -y --quiet python3-genmsg \
-	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.12-1_all.deb -P /tmp/ \
-		&& dpkg -i /tmp/python3-genmsg_0.5.12-1_all.deb \
-		&& apt-get -y autoremove \
-		&& apt-get clean autoclean \
-		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
-RUN apt-get install -y --quiet python3-gencpp \
-	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-gencpp/python3-gencpp_0.6.2-2_all.deb -P /tmp/ \
-		&& dpkg -i /tmp/python3-gencpp_0.6.2-2_all.deb \
-		&& apt-get -y autoremove \
-		&& apt-get clean autoclean \
-		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
-
 # Downgrade Fast-RTPS to 1.7.2 (and replace Fast-RTPS-Gen)
 RUN rm -rf /usr/local/include/fastrtps /usr/local/share/fastrtps /usr/local/lib/libfastrtps* /usr/local/bin/fastrtpsgen \
 	&& git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b 1.7.x /tmp/FastRTPS-1.7.2 \

--- a/docker/Dockerfile_ros2-dashing
+++ b/docker/Dockerfile_ros2-dashing
@@ -56,18 +56,3 @@ RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mix
 	&& colcon mixin update \
 	&& colcon metadata add default https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml \
 	&& colcon metadata update
-
-# install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
-RUN apt-get install -y --quiet python3-genmsg \
-	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.12-1_all.deb -P /tmp/ \
-		&& dpkg -i /tmp/python3-genmsg_0.5.12-1_all.deb \
-		&& apt-get -y autoremove \
-		&& apt-get clean autoclean \
-		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
-RUN apt-get install -y --quiet python3-gencpp \
-	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-gencpp/python3-gencpp_0.6.2-2_all.deb -P /tmp/ \
-		&& dpkg -i /tmp/python3-gencpp_0.6.2-2_all.deb \
-		&& apt-get -y autoremove \
-		&& apt-get clean autoclean \
-		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*

--- a/docker/Dockerfile_ros2-eloquent
+++ b/docker/Dockerfile_ros2-eloquent
@@ -57,21 +57,6 @@ RUN colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mix
 	&& colcon metadata add default https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml \
 	&& colcon metadata update
 
-# install python3-genmsg and python-gencpp or download and install from deb source (currently only available in Ubuntu 18.10 and above)
-RUN apt-get install -y --quiet python3-genmsg \
-	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-genmsg/python3-genmsg_0.5.12-1_all.deb -P /tmp/ \
-		&& dpkg -i /tmp/python3-genmsg_0.5.12-1_all.deb \
-		&& apt-get -y autoremove \
-		&& apt-get clean autoclean \
-		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
-RUN apt-get install -y --quiet python3-gencpp \
-	|| wget http://mirrors.kernel.org/ubuntu/pool/universe/r/ros-gencpp/python3-gencpp_0.6.2-2_all.deb -P /tmp/ \
-		&& dpkg -i /tmp/python3-gencpp_0.6.2-2_all.deb \
-		&& apt-get -y autoremove \
-		&& apt-get clean autoclean \
-		&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
-
 # Intall foonathan_memory from source as it is required to Fast-RTPS >= 1.9
 RUN git clone https://github.com/eProsima/foonathan_memory_vendor.git /tmp/foonathan_memory \
 	&& cd /tmp/foonathan_memory \


### PR DESCRIPTION
https://github.com/PX4/Firmware/pull/13572 removes `genmsg` and `gencpp` submodules. Since `gencpp` is not used, `genmsg` needs to be installed on the containers. https://pypi.org/project/pyros-genmsg/ provides the `genmsg` python package, required to generate the source code for uORB topics and the micro-RTPS bridge.