### PR TITLE
px4-dev-nuttx: revert GNU Arm toolchain update to version 7

### DIFF
--- a/docker/Dockerfile_nuttx
+++ b/docker/Dockerfile_nuttx
@@ -25,9 +25,9 @@ RUN apt-get update \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-# GNU Arm Embedded Toolchain Version 9-2019-q4-major Released: November 06, 2019
+# GNU Arm Embedded Toolchain Version 7-2017-q4-major Released: December 18, 2017
 RUN mkdir -p /opt/gcc && cd /opt/gcc \
-	&& wget -qO- "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2" | tar jx --strip 1 \
+	&& wget -qO- "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2" | tar jx --strip 1 \
 	&& rm -rf /opt/gcc/share/doc
 
 ENV PATH="$PATH:/opt/gcc/bin"


### PR DESCRIPTION
This change, which eventually should be made again as soon as https://github.com/PX4/Firmware/pull/13448 is considered definite and complete, is blocking other unrelated PR's which require updated container tags (like https://github.com/PX4/Firmware/pull/13572).