### PR TITLE
Add clang-format-3.8 for ros kinetic container

### DIFF
--- a/docker/Dockerfile_ros-kinetic
+++ b/docker/Dockerfile_ros-kinetic
@@ -33,6 +33,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 		ros-$ROS_DISTRO-rosunit \
 		ros-$ROS_DISTRO-xacro \
 		xvfb \
+		clang-format-3.8 \
 	&& geographiclib-get-geoids egm96-5 \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \


### PR DESCRIPTION
`clang-format-3.8` is used for format checking in https://github.com/PX4/avoidance and was being installed during build tests as in [this PR](https://github.com/PX4/avoidance/blob/8f872eabc9a014308d876969575b223f9daeb9b4/.github/workflows/check_format.yml#L17)

Installing the clang-format in the container would speed up the ci check 