### PR TITLE
docker: use pip installed by package manager

### DIFF
--- a/docker/Dockerfile_armhf
+++ b/docker/Dockerfile_armhf
@@ -7,7 +7,7 @@
 # Parrot Bebop, or OcPoC-Zynq
 #
 
-FROM px4io/px4-dev-base-bionic:2019-12-18
+FROM px4io/px4-dev-base-bionic:2020-01-06
 
 RUN apt-get update && apt-get -yy --quiet --no-install-recommends install \
 		g++-arm-linux-gnueabihf \

--- a/docker/Dockerfile_base-archlinux
+++ b/docker/Dockerfile_base-archlinux
@@ -25,9 +25,8 @@ RUN pacman -Sy --noconfirm \
 		wget \
 		zip
 
-# python3 dependencies installed by pip
-RUN python3 -m pip install --upgrade pip \
-	&& pip3 install argparse argcomplete coverage cerberus empy jinja2 \
+# Python 3 dependencies installed by pip
+RUN pip3 install argparse argcomplete coverage cerberus empy jinja2 \
 		matplotlib==3.0.* numpy pkgconfig pyros-genmsg pyulog pyyaml \
 		requests serial toml pyulog wheel
 

--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -59,9 +59,8 @@ RUN cd /usr/src/gtest \
 	&& cp *.a /usr/lib \
 	&& cd .. && rm -rf build
 
-# python3 dependencies installed by pip
-RUN python3 -m pip install --upgrade pip \
-	&& pip3 install argparse argcomplete coverage cerberus empy jinja2 \
+# Python 3 dependencies installed by pip
+RUN pip3 install argparse argcomplete coverage cerberus empy jinja2 \
 		matplotlib==3.0.* numpy pkgconfig pyros-genmsg pyulog pyyaml \
 		requests serial toml pyulog wheel
 

--- a/docker/Dockerfile_base-xenial
+++ b/docker/Dockerfile_base-xenial
@@ -59,9 +59,8 @@ RUN cd /usr/src/gtest \
 	&& cp *.a /usr/lib \
 	&& cd .. && rm -rf build
 
-# python3 dependencies installed by pip
-RUN python3 -m pip install --upgrade pip \
-	&& pip3 install argparse argcomplete coverage cerberus empy jinja2 \
+# Python 3 dependencies installed by pip
+RUN pip3 install argparse argcomplete coverage cerberus empy jinja2 \
 		matplotlib==3.0.* numpy pkgconfig pyros-genmsg pyulog pyyaml \
 		requests serial toml pyulog wheel
 

--- a/docker/Dockerfile_clang
+++ b/docker/Dockerfile_clang
@@ -3,7 +3,7 @@
 #  px4-dev-base + latest clang
 #
 
-FROM px4io/px4-dev-base-bionic:2019-12-18
+FROM px4io/px4-dev-base-bionic:2020-01-06
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN wget --quiet http://apt.llvm.org/llvm-snapshot.gpg.key -O - | apt-key add - \

--- a/docker/Dockerfile_nuttx
+++ b/docker/Dockerfile_nuttx
@@ -2,7 +2,7 @@
 # PX4 NuttX development environment
 #
 
-FROM px4io/px4-dev-base-bionic:2019-12-18
+FROM px4io/px4-dev-base-bionic:2020-01-06
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN apt-get update \

--- a/docker/Dockerfile_nuttx_clang
+++ b/docker/Dockerfile_nuttx_clang
@@ -2,7 +2,7 @@
 # PX4 Clang + NuttX development environment
 #
 
-FROM px4io/px4-dev-clang:2019-12-18
+FROM px4io/px4-dev-clang:2020-01-06
 
 RUN dpkg --add-architecture i386 \
 	&& apt-get update \

--- a/docker/Dockerfile_raspi
+++ b/docker/Dockerfile_raspi
@@ -5,7 +5,7 @@
 # Raspberry Pi or Parrot Bebop
 #
 
-FROM px4io/px4-dev-base-bionic:2019-12-18
+FROM px4io/px4-dev-base-bionic:2020-01-06
 LABEL maintainer="Michael Schaeuble"
 
 RUN apt-get update \

--- a/docker/Dockerfile_ros-kinetic
+++ b/docker/Dockerfile_ros-kinetic
@@ -2,7 +2,7 @@
 # PX4 ROS development environment
 #
 
-FROM px4io/px4-dev-simulation-xenial:2019-12-18
+FROM px4io/px4-dev-simulation-xenial:2020-01-06
 LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
 
 ENV ROS_DISTRO kinetic

--- a/docker/Dockerfile_ros-melodic
+++ b/docker/Dockerfile_ros-melodic
@@ -2,7 +2,7 @@
 # PX4 ROS development environment
 #
 
-FROM px4io/px4-dev-simulation-bionic:2019-12-18
+FROM px4io/px4-dev-simulation-bionic:2020-01-06
 LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
 
 ENV ROS_DISTRO melodic

--- a/docker/Dockerfile_ros2-ardent
+++ b/docker/Dockerfile_ros2-ardent
@@ -3,7 +3,7 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-kinetic:2019-12-18
+FROM px4io/px4-dev-ros-kinetic:2020-01-06
 LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
 
 # setup environment

--- a/docker/Dockerfile_ros2-ardent
+++ b/docker/Dockerfile_ros2-ardent
@@ -27,9 +27,8 @@ RUN apt-get install -y --quiet \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-# install python packages needed for testing
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
-	&& python3 -m pip install --upgrade pip \
+# Install python 3 packages needed for testing
+RUN pip3 install --upgrade \
 		argcomplete \
 		colcon-common-extensions \
 		colcon-mixin \

--- a/docker/Dockerfile_ros2-bouncy
+++ b/docker/Dockerfile_ros2-bouncy
@@ -27,9 +27,8 @@ RUN apt-get install -y --quiet \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-# install python packages needed for testing
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
-	&& python3 -m pip install --upgrade pip \
+# Install Python 3 packages needed for testing
+RUN pip3 install --upgrade \
 		argcomplete \
 		colcon-common-extensions \
 		colcon-mixin \

--- a/docker/Dockerfile_ros2-bouncy
+++ b/docker/Dockerfile_ros2-bouncy
@@ -3,7 +3,7 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-melodic:2019-12-18
+FROM px4io/px4-dev-ros-melodic:2020-01-06
 LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
 
 # setup environment

--- a/docker/Dockerfile_ros2-crystal
+++ b/docker/Dockerfile_ros2-crystal
@@ -27,9 +27,8 @@ RUN apt-get install -y --quiet \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-# install python packages needed for testing
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
-	&& python3 -m pip install --upgrade pip \
+# Install Python 3 packages needed for testing
+RUN pip3 install --upgrade \
 		argcomplete \
 		colcon-common-extensions \
 		colcon-mixin \

--- a/docker/Dockerfile_ros2-crystal
+++ b/docker/Dockerfile_ros2-crystal
@@ -3,7 +3,7 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-melodic:2019-12-18
+FROM px4io/px4-dev-ros-melodic:2020-01-06
 LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
 
 # setup environment

--- a/docker/Dockerfile_ros2-dashing
+++ b/docker/Dockerfile_ros2-dashing
@@ -28,9 +28,8 @@ RUN apt-get install -y --quiet \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-# install python packages needed for testing
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
-	&& python3 -m pip install --upgrade pip \
+# Install Python 3 packages needed for testing
+RUN pip3 install --upgrade \
 		argcomplete \
 		colcon-common-extensions \
 		colcon-mixin \

--- a/docker/Dockerfile_ros2-dashing
+++ b/docker/Dockerfile_ros2-dashing
@@ -3,7 +3,7 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-melodic:2019-12-18
+FROM px4io/px4-dev-ros-melodic:2020-01-06
 LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
 
 # setup environment

--- a/docker/Dockerfile_ros2-eloquent
+++ b/docker/Dockerfile_ros2-eloquent
@@ -28,9 +28,8 @@ RUN apt-get install -y --quiet \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-# install python packages needed for testing
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 \
-	&& python3 -m pip install --upgrade pip \
+# Install Python 3 packages needed for testing
+RUN pip3 install --upgrade \
 		argcomplete \
 		colcon-common-extensions \
 		colcon-mixin \

--- a/docker/Dockerfile_ros2-eloquent
+++ b/docker/Dockerfile_ros2-eloquent
@@ -3,7 +3,7 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-melodic:2019-12-18
+FROM px4io/px4-dev-ros-melodic:2020-01-06
 LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
 
 # setup environment

--- a/docker/Dockerfile_simulation-bionic
+++ b/docker/Dockerfile_simulation-bionic
@@ -2,7 +2,7 @@
 # PX4 gazebo development environment
 #
 
-FROM px4io/px4-dev-base-bionic:2019-12-18
+FROM px4io/px4-dev-base-bionic:2020-01-06
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - \

--- a/docker/Dockerfile_simulation-xenial
+++ b/docker/Dockerfile_simulation-xenial
@@ -2,7 +2,7 @@
 # PX4 gazebo development environment
 #
 
-FROM px4io/px4-dev-base-xenial:2019-12-18
+FROM px4io/px4-dev-base-xenial:2020-01-06
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - \


### PR DESCRIPTION
This removes custom install pip install and upgrade commands. Instead we should be relying on what the package manager (mostly apt-get) provides.
Generally, the packages are made so that pip works for Python 2 and pip3 works for Python 3.

Additionally, all date tags are updated so that we can rebuild all the images.