### PR TITLE
docker: SITL needs bc

### DIFF
--- a/docker/Dockerfile_base-archlinux
+++ b/docker/Dockerfile_base-archlinux
@@ -9,6 +9,7 @@ RUN pacman -Sy --noconfirm \
 		arm-none-eabi-gcc \
 		arm-none-eabi-newlib \
 		base-devel \
+		bc \
 		ccache \
 		cmake \
 		git \

--- a/docker/Dockerfile_simulation-bionic
+++ b/docker/Dockerfile_simulation-bionic
@@ -10,6 +10,7 @@ RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add
 	&& apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		ant \
+		bc \
 		gazebo9 \
 		gstreamer1.0-plugins-bad \
 		gstreamer1.0-plugins-base \

--- a/docker/Dockerfile_simulation-xenial
+++ b/docker/Dockerfile_simulation-xenial
@@ -10,6 +10,7 @@ RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add
 	&& apt-get update \
 	&& DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 		ant \
+		bc \
 		gazebo7 \
 		gstreamer1.0-plugins-bad \
 		gstreamer1.0-plugins-base \


### PR DESCRIPTION
When running SITL we need to call bc in the startup script for floating point calculations.

Related to https://github.com/PX4/Firmware/pull/13867.