### PR TITLE
docker: Don't install pip2

### DIFF
--- a/docker/Dockerfile_ros-kinetic
+++ b/docker/Dockerfile_ros-kinetic
@@ -21,7 +21,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 		libyaml-cpp-dev \
 		protobuf-compiler \
 		python-catkin-tools \
-		python-pip \
 		python-tk \
 		ros-$ROS_DISTRO-gazebo-ros-pkgs \
 		ros-$ROS_DISTRO-mav-msgs \
@@ -41,10 +40,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 	&& geographiclib-get-geoids egm96-5 \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
-	# pip2
-	&& pip install px4tools pymavlink \
-	# pip3
-	&& pip3 install catkin_pkg \
+	&& pip3 install catkin_pkg px4tools pymavlink \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update

--- a/docker/Dockerfile_ros-melodic
+++ b/docker/Dockerfile_ros-melodic
@@ -18,7 +18,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 		libopencv-dev \
 		libyaml-cpp-dev \
 		python-catkin-tools \
-		python-pip \
 		python-tk \
 		ros-$ROS_DISTRO-gazebo-ros-pkgs \
 		ros-$ROS_DISTRO-mav-msgs \
@@ -38,10 +37,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 	&& geographiclib-get-geoids egm96-5 \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
-	# pip2
-	&& pip install px4tools pymavlink \
-	# pip3
-	&& pip3 install catkin_pkg \
+	&& pip3 install catkin_pkg px4tools pymavlink \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN rosdep init && rosdep update


### PR DESCRIPTION
This should not be needed at all, hopefully.

I'm hoping that this way we don't run into troubles installing px4tools which in turn tries to install matplotlib which does not install with our old pip version.