### PR TITLE
ROS containers: add python-jinja2

### DIFF
--- a/docker/Dockerfile_ros-kinetic
+++ b/docker/Dockerfile_ros-kinetic
@@ -21,6 +21,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 		libyaml-cpp-dev \
 		protobuf-compiler \
 		python-catkin-tools \
+		python-jinja2 \
 		python-rospkg \
 		python-tk \
 		ros-$ROS_DISTRO-gazebo-ros-pkgs \

--- a/docker/Dockerfile_ros-melodic
+++ b/docker/Dockerfile_ros-melodic
@@ -18,6 +18,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 		libopencv-dev \
 		libyaml-cpp-dev \
 		python-catkin-tools \
+		python-jinja2 \
 		python-rospkg \
 		python-tk \
 		ros-$ROS_DISTRO-gazebo-ros-pkgs \


### PR DESCRIPTION
Required for a `catkin` build (http://ci.px4.io:8080/blue/organizations/jenkins/PX4%2FFirmware/detail/PR-13572/34/pipeline/25).