### PR TITLE
docker: remove MAVSDK install

### DIFF
--- a/docker/Dockerfile_simulation-bionic
+++ b/docker/Dockerfile_simulation-bionic
@@ -40,7 +40,3 @@ ENV SVGA_VGPU10 0
 
 # Use UTF8 encoding in java tools (needed to compile jMAVSim)
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
-
-# Install MAVSDK library
-RUN wget https://github.com/mavlink/MAVSDK/releases/download/v0.23.0/mavsdk_0.23.0_ubuntu18.04_amd64.deb \
-    && dpkg -i mavsdk_0.23.0_ubuntu18.04_amd64.deb


### PR DESCRIPTION
We don't need this as we can easily install it later and therefore move the mavsdk version specification to the Firmware repository.

This is not urgent as we can already replace the installed version in the PX4/Firmware tests.