### PR TITLE
docker: remove ros2bag

### DIFF
--- a/docker/Dockerfile_ros2-ardent
+++ b/docker/Dockerfile_ros2-ardent
@@ -22,7 +22,6 @@ RUN apt-get install -y --quiet \
 		python3-colcon-common-extensions \
 		python3-vcstool \
 		ros-$ROS2_DISTRO-desktop \
-		ros-$ROS2_DISTRO-ros2bag \
 		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \

--- a/docker/Dockerfile_ros2-bouncy
+++ b/docker/Dockerfile_ros2-bouncy
@@ -22,7 +22,6 @@ RUN apt-get install -y --quiet \
 		python3-colcon-common-extensions \
 		python3-vcstool \
 		ros-$ROS2_DISTRO-desktop \
-		ros-$ROS2_DISTRO-ros2bag \
 		ros-$ROS2_DISTRO-rosidl-generator-dds-idl \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \


### PR DESCRIPTION
Because it did not exist yet.