### PR TITLE
add px4-dev-base-focal (Ubuntu 20.04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ License: according to [LICENSE](https://github.com/PX4/Firmware/blob/master/LICE
             - [px4io/px4-dev-ros2-crystal](https://hub.docker.com/r/px4io/px4-dev-ros2-crystal) [![](https://images.microbadger.com/badges/image/px4io/px4-dev-ros2-crystal.svg)](http://microbadger.com/images/px4io/px4-dev-ros2-crystal) [![Docker Pulls](https://img.shields.io/docker/pulls/px4io/px4-dev-ros2-crystal.svg)](https://hub.docker.com/r/px4io/px4-dev-ros2-crystal)
             - [px4io/px4-dev-ros2-dashing](https://hub.docker.com/r/px4io/px4-dev-ros2-dashing) [![](https://images.microbadger.com/badges/image/px4io/px4-dev-ros2-dashing.svg)](http://microbadger.com/images/px4io/px4-dev-ros2-dashing) [![Docker Pulls](https://img.shields.io/docker/pulls/px4io/px4-dev-ros2-dashing.svg)](https://hub.docker.com/r/px4io/px4-dev-ros2-dashing)
             - [px4io/px4-dev-ros2-eloquent](https://hub.docker.com/r/px4io/px4-dev-ros2-eloquent) [![](https://images.microbadger.com/badges/image/px4io/px4-dev-ros2-eloquent.svg)](http://microbadger.com/images/px4io/px4-dev-ros2-eloquent) [![Docker Pulls](https://img.shields.io/docker/pulls/px4io/px4-dev-ros2-eloquent.svg)](https://hub.docker.com/r/px4io/px4-dev-ros2-eloquent)
+- px4io/px4-dev-base-focal
 - [px4io/px4-dev-base-xenial](https://hub.docker.com/r/px4io/px4-dev-base-xenial) [![](https://images.microbadger.com/badges/image/px4io/px4-dev-base-xenial.svg)](http://microbadger.com/images/px4io/px4-dev-base-xenial) [![Docker Pulls](https://img.shields.io/docker/pulls/px4io/px4-dev-base-xenial.svg)](https://hub.docker.com/r/px4io/px4-dev-base-xenial)
     - [px4io/px4-dev-simulation-xenial](https://hub.docker.com/r/px4io/px4-dev-simulation-xenial) [![](https://images.microbadger.com/badges/image/px4io/px4-dev-simulation-xenial.svg)](http://microbadger.com/images/px4io/px4-dev-simulation-xenial) [![Docker Pulls](https://img.shields.io/docker/pulls/px4io/px4-dev-simulation-xenial.svg)](https://hub.docker.com/r/px4io/px4-dev-simulation-xenial)
         - [px4io/px4-dev-ros-kinetic](https://hub.docker.com/r/px4io/px4-dev-ros-kinetic) [![](https://images.microbadger.com/badges/image/px4io/px4-dev-ros-kinetic.svg)](http://microbadger.com/images/px4io/px4-dev-ros-kinetic) [![Docker Pulls](https://img.shields.io/docker/pulls/px4io/px4-dev-ros-kinetic.svg)](https://hub.docker.com/r/px4io/px4-dev-ros-kinetic)
@@ -57,7 +58,3 @@ or:
 cd docker
 make px4-dev-ros-melodic
 ```
-
-
-
-

--- a/docker/Dockerfile_base-focal
+++ b/docker/Dockerfile_base-focal
@@ -1,0 +1,135 @@
+#
+# PX4 base development environment
+#
+
+FROM ubuntu:20.04
+LABEL maintainer="Daniel Agar <daniel@agar.ca>"
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
+		bzip2 \
+		ca-certificates \
+		ccache \
+		cmake \
+		cppcheck \
+		curl \
+		dirmngr \
+		doxygen \
+		file \
+		g++ \
+		gcc \
+		gdb \
+		git \
+		gnupg \
+		gosu \
+		lcov \
+		libfreetype6-dev \
+		libgtest-dev \
+		libpng-dev \
+		libssl-dev \
+		lsb-release \
+		make \
+		ninja-build \
+		openjdk-8-jdk \
+		openjdk-8-jre \
+		openssh-client \
+		pkg-config \
+		python3-dev \
+		python3-pip \
+		rsync \
+		shellcheck \
+		tzdata \
+		unzip \
+		valgrind \
+		wget \
+		xsltproc \
+		zip \
+	&& apt-get -y autoremove \
+	&& apt-get clean autoclean \
+	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# gtest
+RUN cd /usr/src/gtest \
+	&& mkdir build && cd build \
+	&& cmake .. && make -j$(nproc) \
+	&& find . -name \*.a -exec cp {} /usr/lib \; \
+	&& cd .. && rm -rf build
+
+# Install Python 3 pip build dependencies first.
+RUN python3 -m pip install --upgrade pip wheel setuptools
+
+# Python 3 dependencies installed by pip
+RUN python3 -m pip install argparse argcomplete coverage cerberus empy jinja2 \
+		matplotlib==3.0.* numpy packaging pkgconfig pyros-genmsg pyulog \
+		pyyaml requests serial six toml psutil pyulog wheel
+
+# manual ccache setup
+RUN ln -s /usr/bin/ccache /usr/lib/ccache/cc \
+	&& ln -s /usr/bin/ccache /usr/lib/ccache/c++
+
+# astyle v2.06
+RUN wget -q https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.06/astyle_2.06_linux.tar.gz -O /tmp/astyle.tar.gz \
+	&& cd /tmp && tar zxf astyle.tar.gz && cd astyle/src \
+	&& make -f ../build/gcc/Makefile -j$(nproc) && cp bin/astyle /usr/local/bin \
+	&& rm -rf /tmp/*
+
+# Gradle (Required to build Fast-RTPS-Gen)
+RUN wget -q "https://services.gradle.org/distributions/gradle-6.3-rc-4-bin.zip" -O /tmp/gradle-6.3-rc-4-bin.zip \
+	&& mkdir /opt/gradle \
+	&& cd /tmp \
+	&& unzip -d /opt/gradle gradle-6.3-rc-4-bin.zip \
+	&& rm -rf /tmp/*
+
+ENV PATH "/opt/gradle/gradle-6.3-rc-4/bin:$PATH"
+
+# Intall foonathan_memory from source as it is required to Fast-RTPS >= 1.9
+RUN git clone https://github.com/eProsima/foonathan_memory_vendor.git /tmp/foonathan_memory \
+	&& cd /tmp/foonathan_memory \
+	&& mkdir build && cd build \
+	&& cmake .. \
+	&& cmake --build . --target install -- -j $(nproc) \
+	&& rm -rf /tmp/*
+
+# Fast-RTPS 1.9.4
+RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b v1.9.4 /tmp/FastRTPS-1.9.4 \
+	&& cd /tmp/FastRTPS-1.9.4 \
+	&& mkdir build && cd build \
+	&& cmake -DTHIRDPARTY=ON -DSECURITY=ON .. \
+	&& cmake --build . --target install -- -j $(nproc) \
+	&& rm -rf /tmp/*
+
+# Fast-RTPS-Gen 1.0.3 (required since Fast-RTPS-Gen got split from Fast-RTPS repo since 1.8.x)
+RUN git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.3 /tmp/Fast-RTPS-Gen \
+	&& cd /tmp/Fast-RTPS-Gen \
+	&& gradle assemble \
+	&& cp share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/ \
+	&& cp scripts/fastrtpsgen /usr/local/bin/ \
+	&& rm -rf /tmp/*
+
+# create user with id 1001 (jenkins docker workflow default)
+RUN useradd --shell /bin/bash -u 1001 -c "" -m user && usermod -a -G dialout user
+
+# setup virtual X server
+RUN mkdir /tmp/.X11-unix && \
+	chmod 1777 /tmp/.X11-unix && \
+	chown -R root:root /tmp/.X11-unix
+ENV DISPLAY :99
+
+ENV CCACHE_UMASK=000
+ENV FASTRTPSGEN_DIR="/usr/local/bin/"
+ENV PATH="/usr/lib/ccache:$PATH"
+ENV TERM=xterm
+ENV TZ=UTC
+
+# SITL UDP PORTS
+EXPOSE 14556/udp
+EXPOSE 14557/udp
+
+# create and start as LOCAL_USER_ID
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["/bin/bash"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,17 +1,19 @@
 
 .PHONY: px4-dev-armhf, px4-dev-base-archlinux, px4-dev-base-bionic, \
-		px4-dev-base-xenial, px4-dev-clang, px4-dev-nuttx, \
-		px4-dev-nuttx-clang, px4-dev-raspi, px4-dev-ros-kinetic, \
-		px4-dev-ros-melodic, px4-dev-ros2-ardent, px4-dev-ros2-bouncy, \
-		px4-dev-ros2-crystal, px4-dev-ros2-dashing, px4-dev-ros2-eloquent, \
-		px4-dev-simulation-xenial, px4-dev-simulation-bionic
+		px4-dev-base-focal, px4-dev-base-xenial, px4-dev-clang, \
+		px4-dev-nuttx, px4-dev-nuttx-clang, px4-dev-raspi, \
+		px4-dev-ros-kinetic, px4-dev-ros-melodic, px4-dev-ros2-ardent, \
+		px4-dev-ros2-bouncy, px4-dev-ros2-crystal, px4-dev-ros2-dashing, px4-dev-ros2-eloquent, \
+		px4-dev-ros2-eloquent, px4-dev-simulation-xenial, \
+		px4-dev-simulation-bionic
 
 all: px4-dev-armhf, px4-dev-base-archlinux, px4-dev-base-bionic, \
-		px4-dev-base-xenial, px4-dev-clang, px4-dev-nuttx, \
-		px4-dev-nuttx-clang, px4-dev-raspi, px4-dev-ros-kinetic, \
-		px4-dev-ros-melodic, px4-dev-ros2-ardent, px4-dev-ros2-bouncy, \
-		px4-dev-ros2-crystal, px4-dev-ros2-dashing, px4-dev-ros2-eloquent, \
-		px4-dev-simulation-xenial, px4-dev-simulation-bionic
+		px4-dev-base-focal, px4-dev-base-xenial, px4-dev-clang, \
+		px4-dev-nuttx, px4-dev-nuttx-clang, px4-dev-raspi, \
+		px4-dev-ros-kinetic, px4-dev-ros-melodic, px4-dev-ros2-ardent, \
+		px4-dev-ros2-bouncy, px4-dev-ros2-crystal, px4-dev-ros2-dashing, px4-dev-ros2-eloquent, \
+		px4-dev-ros2-eloquent, px4-dev-simulation-xenial, \
+		px4-dev-simulation-bionic
 
 px4-dev-armhf:
 	docker build -t px4io/px4-dev-armhf . -f Dockerfile_armhf
@@ -21,6 +23,9 @@ px4-dev-base-archlinux:
 
 px4-dev-base-bionic:
 	docker build -t px4io/px4-dev-base-bionic . -f Dockerfile_base-bionic
+
+px4-dev-base-focal:
+	docker build -t px4io/px4-dev-base-focal . -f Dockerfile_base-focal
 
 px4-dev-base-xenial:
 	docker build -t px4io/px4-dev-base-xenial . -f Dockerfile_base-xenial


### PR DESCRIPTION
Built and tested locally with the `px4_sitl_rtps` target. Runs SITL (with no sim) as expected.