### PR TITLE
Fast-RTPS setup: general updates

### DIFF
--- a/docker/Dockerfile_base-bionic
+++ b/docker/Dockerfile_base-bionic
@@ -77,13 +77,13 @@ RUN wget -q https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.0
 	&& rm -rf /tmp/*
 
 # Gradle (Required to build Fast-RTPS-Gen)
-RUN wget -q "https://services.gradle.org/distributions/gradle-6.1-rc-3-bin.zip" -O /tmp/gradle-6.1-rc-3-bin.zip \
+RUN wget -q "https://services.gradle.org/distributions/gradle-6.3-rc-4-bin.zip" -O /tmp/gradle-6.3-rc-4-bin.zip \
 	&& mkdir /opt/gradle \
 	&& cd /tmp \
-	&& unzip -d /opt/gradle gradle-6.1-rc-3-bin.zip \
+	&& unzip -d /opt/gradle gradle-6.3-rc-4-bin.zip \
 	&& rm -rf /tmp/*
 
-ENV PATH "/opt/gradle/gradle-6.1-rc-3/bin:$PATH"
+ENV PATH "/opt/gradle/gradle-6.3-rc-4/bin:$PATH"
 
 # Fast-RTPS 1.8.2
 RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b v1.8.2 /tmp/FastRTPS-1.8.2 \
@@ -93,12 +93,11 @@ RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b v1.8.2 /t
 	&& cmake --build . --target install -- -j $(nproc) \
 	&& rm -rf /tmp/*
 
-# Fast-RTPS-Gen 1.0.3 (required since Fast-RTPS-Gen got split from Fast-RTPS repo since 1.8.x)
-RUN git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.3 /tmp/Fast-RTPS-Gen \
-	&& cd /tmp/Fast-RTPS-Gen \
+# Fast-RTPS-Gen 1.0.4
+RUN git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.4 /tmp/Fast-RTPS-Gen-1.0.4 \
+	&& cd /tmp/Fast-RTPS-Gen-1.0.4 \
 	&& gradle assemble \
-	&& cp share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/ \
-	&& cp scripts/fastrtpsgen /usr/local/bin/ \
+	&& gradle install \
 	&& rm -rf /tmp/*
 
 # create user with id 1001 (jenkins docker workflow default)

--- a/docker/Dockerfile_base-focal
+++ b/docker/Dockerfile_base-focal
@@ -101,12 +101,11 @@ RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b v1.9.4 /t
 	&& cmake --build . --target install -- -j $(nproc) \
 	&& rm -rf /tmp/*
 
-# Fast-RTPS-Gen 1.0.3 (required since Fast-RTPS-Gen got split from Fast-RTPS repo since 1.8.x)
-RUN git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.3 /tmp/Fast-RTPS-Gen \
-	&& cd /tmp/Fast-RTPS-Gen \
+# Fast-RTPS-Gen 1.0.4
+RUN git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.4 /tmp/Fast-RTPS-Gen-1.0.4 \
+	&& cd /tmp/Fast-RTPS-Gen-1.0.4 \
 	&& gradle assemble \
-	&& cp share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/ \
-	&& cp scripts/fastrtpsgen /usr/local/bin/ \
+	&& gradle install \
 	&& rm -rf /tmp/*
 
 # create user with id 1001 (jenkins docker workflow default)

--- a/docker/Dockerfile_base-xenial
+++ b/docker/Dockerfile_base-xenial
@@ -76,12 +76,20 @@ RUN wget -q https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.0
 	&& make -f ../build/gcc/Makefile -j$(nproc) && cp bin/astyle /usr/local/bin \
 	&& rm -rf /tmp/*
 
-# Fast-RTPS
-RUN wget -q "http://www.eprosima.com/index.php/component/ars/repository/eprosima-fast-rtps/eprosima-fast-rtps-1-6-0/eprosima_fastrtps-1-6-0-linux-tar-gz?format=raw" -O /tmp/eprosima_fastrtps.tar.gz \
-	&& cd /tmp && tar zxf eprosima_fastrtps.tar.gz \
-	&& cd eProsima_FastRTPS-1.6.0-Linux \
-	&& ./configure CXXFLAGS="-g -D__DEBUG" --libdir=/usr/lib \
-	&& make -j$(nproc) install \
+# Fast-CDR 1.0.7
+RUN git clone --recursive https://github.com/eProsima/Fast-CDR.git -b v1.0.7 /tmp/FastCDR-1.0.7 \
+	&& cd /tmp/FastCDR-1.0.7 \
+	&& mkdir build && cd build \
+	&& cmake -DBUILD_SHARED_LIBS=ON .. \
+	&& cmake --build . --target install -- -j $(nproc) \
+	&& rm -rf /tmp/*
+
+# Fast-RTPS 1.6.0
+RUN git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b v1.6.0 /tmp/FastRTPS-1.6.0 \
+	&& cd /tmp/FastRTPS-1.6.0 \
+	&& mkdir build && cd build \
+	&& cmake -DBUILD_JAVA=ON -DSECURITY=ON -DTHIRDPARTY=ON .. \
+	&& cmake --build . --target install -- -j $(nproc) \
 	&& rm -rf /tmp/*
 
 # create user with id 1001 (jenkins docker workflow default)

--- a/docker/Dockerfile_ros2-eloquent
+++ b/docker/Dockerfile_ros2-eloquent
@@ -63,18 +63,10 @@ RUN git clone https://github.com/eProsima/foonathan_memory_vendor.git /tmp/foona
 	&& rm -rf /tmp/*
 
 # Install Fast-RTPS 1.9.3
-RUN rm -rf /usr/local/include/fastrtps /usr/local/share/fastrtps /usr/local/lib/libfastrtps* /usr/local/bin/fastrtpsgen \
+RUN rm -rf /usr/local/include/fastrtps /usr/local/share/fastrtps /usr/local/lib/libfastrtps* \
 	&& git clone --recursive https://github.com/eProsima/Fast-RTPS.git -b v1.9.3 /tmp/FastRTPS-1.9.3 \
 	&& cd /tmp/FastRTPS-1.9.3 \
 	&& mkdir build && cd build \
 	&& cmake -DTHIRDPARTY=ON -DSECURITY=ON .. \
 	&& cmake --build . --target install -- -j $(nproc) \
-	&& rm -rf /tmp/*
-
-# Fast-RTPS-Gen (required since Fast-RTPS-Gen got split from Fast-RTPS repo since 1.8.x)
-RUN git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git -b v1.0.3 /tmp/Fast-RTPS-Gen \
-	&& cd /tmp/Fast-RTPS-Gen \
-	&& gradle assemble \
-	&& cp share/fastrtps/fastrtpsgen.jar /usr/local/share/fastrtps/ \
-	&& cp scripts/fastrtpsgen /usr/local/bin/ \
 	&& rm -rf /tmp/*


### PR DESCRIPTION
*  _px4-dev-base-bionic_:
    -  bump Fast-RTPS-Gen to **v1.0.4**;
    -  bump Gradle to **6.3-rc4**;
*  _px4-dev-base-focal_:
    -  bump Fast-RTPS-Gen to **v1.0.4**;
*  _px4-dev-base-xenial_:
    -  install Fast-CDR 1.0.7 from source so the CMake modules to find it are made available;
    -  install Fast-RTPS 1.6.0 from source.

Fast-RTPS-Gen v1.0.4 release notes: https://github.com/eProsima/Fast-RTPS-Gen/releases/tag/v1.0.4, being the `-typeros2` option the most relevant to us.