### PR TITLE
px4-dev-base-xenial: fix numpy version in 1.18.*

### DIFF
--- a/docker/Dockerfile_base-xenial
+++ b/docker/Dockerfile_base-xenial
@@ -63,7 +63,7 @@ RUN pip3 install wheel setuptools
 
 # Python 3 dependencies installed by pip
 RUN pip3 install argparse argcomplete coverage cerberus empy jinja2 \
-		matplotlib==3.0.* numpy packaging pkgconfig pyros-genmsg pyulog \
+		matplotlib==3.0.* numpy==1.18.* packaging pkgconfig pyros-genmsg pyulog \
 		pyyaml requests serial six toml psutil pyulog wheel
 
 # manual ccache setup


### PR DESCRIPTION
Fixes https://github.com/PX4/containers/runs/813776212?check_suite_focus=true#step:4:1763.