### PR TITLE
nuttx: update GNU Arm Embedded Toolchain to 9-2020-q2-update

### DIFF
--- a/docker/Dockerfile_nuttx-bionic
+++ b/docker/Dockerfile_nuttx-bionic
@@ -25,9 +25,9 @@ RUN apt-get update \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-# GNU Arm Embedded Toolchain Version 9-2019-q4-major Released: November 06, 2019
+# GNU Arm Embedded Toolchain: 9-2020-q2-update Released: June 30, 2020
 RUN mkdir -p /opt/gcc && cd /opt/gcc \
-	&& wget -qO- "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2" | tar jx --strip 1 \
+	&& wget -qO- "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2" | tar jx --strip 1 \
 	&& rm -rf /opt/gcc/share/doc
 
 ENV PATH="$PATH:/opt/gcc/bin"

--- a/docker/Dockerfile_nuttx-focal
+++ b/docker/Dockerfile_nuttx-focal
@@ -25,9 +25,9 @@ RUN apt-get update \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-# GNU Arm Embedded Toolchain Version 9-2019-q4-major Released: November 06, 2019
+# GNU Arm Embedded Toolchain: 9-2020-q2-update Released: June 30, 2020
 RUN mkdir -p /opt/gcc && cd /opt/gcc \
-	&& wget -qO- "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2" | tar jx --strip 1 \
+	&& wget -qO- "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2" | tar jx --strip 1 \
 	&& rm -rf /opt/gcc/share/doc
 
 ENV PATH="$PATH:/opt/gcc/bin"


### PR DESCRIPTION
Updates the GNU Arm Embedded Toolchain to version 9-2020-q2-update (released in November 30, 2020) in both Bionic and Focal `nuttx` containers.