### PR TITLE
Fix catkin on ROS noetic

### DIFF
--- a/docker/Dockerfile_ros-noetic
+++ b/docker/Dockerfile_ros-noetic
@@ -19,6 +19,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 		libyaml-cpp-dev \
 		python3-rosdep \
 		python3-catkin-tools \
+		python3-catkin-lint \
 		ros-$ROS_DISTRO-gazebo-ros-pkgs \
 		ros-$ROS_DISTRO-mavlink \
 		ros-$ROS_DISTRO-mavros \
@@ -36,6 +37,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6B
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+RUN pip3 install -U \
+		osrf-pycommon
 
 # bootstrap rosdep
 RUN rosdep init && rosdep update


### PR DESCRIPTION
catkin package was broken on Ubuntu focal(ROS noetic)

This was due to the missing dependency, which is added in this PR

from: https://github.com/catkin/catkin_tools/issues/594#issuecomment-651938327
