### PR TITLE
Install jsbsim in simulation container

### DIFF
--- a/docker/Dockerfile_simulation-bionic
+++ b/docker/Dockerfile_simulation-bionic
@@ -37,5 +37,5 @@ ENV QT_X11_NO_MITSHM 1
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 # Install JSBSim
-RUN wget https://github.com/JSBSim-Team/jsbsim/releases/download/Linux/JSBSim-devel_1.1.0.dev1Ubuntu18.04.amd64.deb
-RUN dpkg -i JSBSim-devel_1.1.0.dev1Ubuntu18.04.amd64.deb
+RUN wget https://github.com/JSBSim-Team/jsbsim/releases/download/Linux/JSBSim-devel_1.1.0.dev1-85.bionic.amd64.deb
+RUN dpkg -i JSBSim-devel_1.1.0.dev1-85.bionic.amd64.deb

--- a/docker/Dockerfile_simulation-bionic
+++ b/docker/Dockerfile_simulation-bionic
@@ -35,3 +35,7 @@ ENV QT_X11_NO_MITSHM 1
 
 # Use UTF8 encoding in java tools (needed to compile jMAVSim)
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+
+# Install JSBSim
+RUN wget https://github.com/JSBSim-Team/jsbsim/releases/download/Linux/JSBSim-devel_1.1.0.dev1Ubuntu18.04.amd64.deb
+RUN dpkg -i JSBSim-devel_1.1.0.dev1Ubuntu18.04.amd64.deb

--- a/docker/Dockerfile_simulation-focal
+++ b/docker/Dockerfile_simulation-focal
@@ -39,3 +39,7 @@ ENV QT_X11_NO_MITSHM 1
 
 # Use UTF8 encoding in java tools (needed to compile jMAVSim)
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+
+# Install JSBSim
+RUN wget https://github.com/JSBSim-Team/jsbsim/releases/download/Linux/JSBSim-devel_1.1.0.dev1Ubuntu20.04.amd64.deb
+RUN dpkg -i JSBSim-devel_1.1.0.dev1Ubuntu20.04.amd64.deb

--- a/docker/Dockerfile_simulation-focal
+++ b/docker/Dockerfile_simulation-focal
@@ -41,5 +41,5 @@ ENV QT_X11_NO_MITSHM 1
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 # Install JSBSim
-RUN wget https://github.com/JSBSim-Team/jsbsim/releases/download/Linux/JSBSim-devel_1.1.0.dev1Ubuntu20.04.amd64.deb
-RUN dpkg -i JSBSim-devel_1.1.0.dev1Ubuntu20.04.amd64.deb
+RUN wget https://github.com/JSBSim-Team/jsbsim/releases/download/Linux/JSBSim-devel_1.1.0.dev1-85.focal.amd64.deb
+RUN dpkg -i JSBSim-devel_1.1.0.dev1-85.focal.amd64.deb


### PR DESCRIPTION
This installs [jsbsim](https://github.com/JSBSim-Team/jsbsim) in the bionic simulation container.

This will enable build/SITL testing on JSBSim

The deb package is ~2.8MB