### PR TITLE
Add yarn to dockerfile.

### DIFF
--- a/docker/Dockerfile_docs
+++ b/docker/Dockerfile_docs
@@ -16,6 +16,7 @@ RUN apt-get update \
 		npm \
 		ruby-dev \
 		zlib1g-dev \
+		yarn \
 	&& apt-get -y autoremove \
 	&& apt-get clean autoclean \
 	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*


### PR DESCRIPTION
@dagar I'm investigating using Vuepress instead of gitbook for building docs instead of yarn. This adds yarn to the docs environment and will allow me to experiment with the jenkinsfile part of the story. Note, it doesn't clean up gitbook stuff - would not do that until this is all live.