### PR TITLE
Update base container for ros melodic/noetic

### DIFF
--- a/docker/Dockerfile_clang
+++ b/docker/Dockerfile_clang
@@ -3,7 +3,7 @@
 #  px4-dev-base + latest clang
 #
 
-FROM px4io/px4-dev-base-bionic:2020-06-28
+FROM px4io/px4-dev-base-bionic:2020-10-20
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN wget --quiet http://apt.llvm.org/llvm-snapshot.gpg.key -O - | apt-key add - \

--- a/docker/Dockerfile_nuttx-bionic
+++ b/docker/Dockerfile_nuttx-bionic
@@ -2,7 +2,7 @@
 # PX4 NuttX development environment in Ubuntu 18.04 Bionic
 #
 
-FROM px4io/px4-dev-base-bionic:2020-06-28
+FROM px4io/px4-dev-base-bionic:2020-10-20
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN apt-get update \

--- a/docker/Dockerfile_nuttx-focal
+++ b/docker/Dockerfile_nuttx-focal
@@ -2,7 +2,7 @@
 # PX4 NuttX development environment in Ubuntu 20.04 Focal
 #
 
-FROM px4io/px4-dev-base-focal:2020-06-28
+FROM px4io/px4-dev-base-focal:2020-10-20
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN apt-get update \

--- a/docker/Dockerfile_nuttx_clang
+++ b/docker/Dockerfile_nuttx_clang
@@ -2,7 +2,7 @@
 # PX4 Clang + NuttX development environment
 #
 
-FROM px4io/px4-dev-clang:2020-06-28
+FROM px4io/px4-dev-clang:2020-10-20
 
 RUN dpkg --add-architecture i386 \
 	&& apt-get update \

--- a/docker/Dockerfile_raspi
+++ b/docker/Dockerfile_raspi
@@ -5,7 +5,7 @@
 # Raspberry Pi or Parrot Bebop
 #
 
-FROM px4io/px4-dev-base-bionic:2020-06-28
+FROM px4io/px4-dev-base-bionic:2020-10-20
 LABEL maintainer="Michael Schaeuble"
 
 RUN apt-get update \

--- a/docker/Dockerfile_ros-kinetic
+++ b/docker/Dockerfile_ros-kinetic
@@ -2,7 +2,7 @@
 # PX4 ROS development environment
 #
 
-FROM px4io/px4-dev-simulation-xenial:2020-06-28
+FROM px4io/px4-dev-simulation-xenial:2020-10-20
 LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
 
 ENV ROS_DISTRO kinetic

--- a/docker/Dockerfile_ros-melodic
+++ b/docker/Dockerfile_ros-melodic
@@ -2,7 +2,7 @@
 # PX4 ROS development environment
 #
 
-FROM px4io/px4-dev-simulation-bionic:2020-06-28
+FROM px4io/px4-dev-simulation-bionic:2020-10-20
 LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
 
 ENV ROS_DISTRO melodic

--- a/docker/Dockerfile_ros-noetic
+++ b/docker/Dockerfile_ros-noetic
@@ -2,7 +2,7 @@
 # PX4 ROS development environment
 #
 
-FROM px4io/px4-dev-simulation-focal:2020-06-28
+FROM px4io/px4-dev-simulation-focal:2020-10-20
 LABEL maintainer="Nuno Marques <n.marques21@hotmail.com>"
 
 ENV ROS_DISTRO noetic

--- a/docker/Dockerfile_ros2-ardent
+++ b/docker/Dockerfile_ros2-ardent
@@ -3,7 +3,7 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-kinetic:2020-06-28
+FROM px4io/px4-dev-ros-kinetic:2020-10-20
 LABEL maintainer="Nuno Marques <nuno.marques@dronesolutions.io>"
 
 # setup environment

--- a/docker/Dockerfile_ros2-bouncy
+++ b/docker/Dockerfile_ros2-bouncy
@@ -3,7 +3,7 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-melodic:2020-06-28
+FROM px4io/px4-dev-ros-melodic:2020-10-20
 LABEL maintainer="Nuno Marques <nuno.marques@dronesolutions.io>"
 
 # setup environment

--- a/docker/Dockerfile_ros2-crystal
+++ b/docker/Dockerfile_ros2-crystal
@@ -3,7 +3,7 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-melodic:2020-06-28
+FROM px4io/px4-dev-ros-melodic:2020-10-20
 LABEL maintainer="Nuno Marques <nuno.marques@dronesolutions.io>"
 
 # setup environment

--- a/docker/Dockerfile_ros2-dashing
+++ b/docker/Dockerfile_ros2-dashing
@@ -3,7 +3,7 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-melodic:2020-06-28
+FROM px4io/px4-dev-ros-melodic:2020-10-20
 LABEL maintainer="Nuno Marques <nuno.marques@dronesolutions.io>"
 
 # setup environment

--- a/docker/Dockerfile_ros2-eloquent
+++ b/docker/Dockerfile_ros2-eloquent
@@ -3,7 +3,7 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-melodic:2020-06-28
+FROM px4io/px4-dev-ros-melodic:2020-10-20
 LABEL maintainer="Nuno Marques <nuno.marques@dronesolutions.io>"
 
 # setup environment

--- a/docker/Dockerfile_ros2-foxy
+++ b/docker/Dockerfile_ros2-foxy
@@ -3,7 +3,7 @@
 # Based from container under https://github.com/osrf/docker_images/tree/master/ros2/source/devel
 #
 
-FROM px4io/px4-dev-ros-noetic:2020-06-28
+FROM px4io/px4-dev-ros-noetic:2020-10-20
 LABEL maintainer="Nuno Marques <nuno.marques@dronesolutions.io>"
 
 # setup environment

--- a/docker/Dockerfile_simulation-bionic
+++ b/docker/Dockerfile_simulation-bionic
@@ -2,7 +2,7 @@
 # PX4 Gazebo 9 development environment in Ubuntu 18.04 Bionic
 #
 
-FROM px4io/px4-dev-base-bionic:2020-06-28
+FROM px4io/px4-dev-base-bionic:2020-10-20
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - \
@@ -37,5 +37,5 @@ ENV QT_X11_NO_MITSHM 1
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 # Install JSBSim
-RUN wget https://github.com/JSBSim-Team/jsbsim/releases/download/Linux/JSBSim-devel_1.1.0.dev1-85.bionic.amd64.deb
-RUN dpkg -i JSBSim-devel_1.1.0.dev1-85.bionic.amd64.deb
+RUN wget -r https://github.com/JSBSim-Team/jsbsim/releases -A "download/v1.1.0/JSBSim-devel_1.1.0-*.bionic.amd64.deb"
+RUN dpkg -i JSBSim-devel_1.1.0-*.bionic.amd64.deb

--- a/docker/Dockerfile_simulation-focal
+++ b/docker/Dockerfile_simulation-focal
@@ -2,7 +2,7 @@
 # PX4 Gazebo 11 development environment in Ubuntu 20.04 Focal
 #
 
-FROM px4io/px4-dev-base-focal:2020-06-28
+FROM px4io/px4-dev-base-focal:2020-10-20
 LABEL maintainer="Nuno Marques <nuno.marques@dronesolutions.io>"
 
 RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - \
@@ -41,5 +41,5 @@ ENV QT_X11_NO_MITSHM 1
 ENV JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 # Install JSBSim
-RUN wget https://github.com/JSBSim-Team/jsbsim/releases/download/Linux/JSBSim-devel_1.1.0.dev1-85.focal.amd64.deb
-RUN dpkg -i JSBSim-devel_1.1.0.dev1-85.focal.amd64.deb
+RUN wget -r https://github.com/JSBSim-Team/jsbsim/releases -A "download/v1.1.0/JSBSim-devel_1.1.0-*.focal.amd64.deb"
+RUN dpkg -i JSBSim-devel_1.1.0-*.focal.amd64.deb

--- a/docker/Dockerfile_simulation-xenial
+++ b/docker/Dockerfile_simulation-xenial
@@ -2,7 +2,7 @@
 # PX4 Gazebo 9 development environment in Ubuntu 20.04 Xenial
 #
 
-FROM px4io/px4-dev-base-xenial:2020-06-28
+FROM px4io/px4-dev-base-xenial:2020-10-20
 LABEL maintainer="Daniel Agar <daniel@agar.ca>"
 
 RUN wget --quiet http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - \


### PR DESCRIPTION
**Problem Description**
While trying to [add catkin build tests](https://github.com/Auterion/px4-jsbsim-bridge/pull/20) to the PX4/px4-jsbsim-bridge, catkin build tests wouldn't pass since jsbsim wasn't installed inside the container. 

Since JSBSim was added in https://github.com/PX4/containers/pull/276, the base containers of the ROS containers need to be updated